### PR TITLE
add resembler set/get quality

### DIFF
--- a/examples/testresample.rs
+++ b/examples/testresample.rs
@@ -20,6 +20,9 @@ fn main() {
     st.set_rate(RATE, rate);
     st.skip_zeros();
 
+    st.set_quality(10).unwrap();
+    eprintln!("Quality: {}", st.get_quality());
+
     loop {
         let in_len = avail as usize;
         let out_len = (in_len * rate + RATE - 1) / RATE;
@@ -29,7 +32,7 @@ fn main() {
 
         let (in_len, out_len) = st.process_float(0, &fin[off .. off + in_len], &mut fout[..out_len]).unwrap();
 
-        eprintln!("{} {} {} {} -> {} {}", rate, off, prev_in_len, prev_out_len, in_len, out_len);
+        println!("{} {} {} {} -> {} {}", rate, off, prev_in_len, prev_out_len, in_len, out_len);
 
         off += in_len as usize;
         avail += INBLOCK as isize - in_len as isize;

--- a/src/resampler.rs
+++ b/src/resampler.rs
@@ -116,6 +116,22 @@ impl State {
     pub fn get_output_latency(&self) -> usize {
         unsafe { speex_resampler_get_output_latency(self.st) as usize }
     }
+
+    pub fn set_quality(&self, quality: usize) -> Result<(), Error> {
+        let ret = unsafe { speex_resampler_set_quality(self.st, quality as i32) };
+        if ret != 0 {
+            Err(Error::from_i32(ret))
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn get_quality(&self) -> usize {
+        let mut c_get = 0;
+        unsafe { speex_resampler_get_quality(self.st, &mut c_get);}
+        c_get as usize
+    }
+
 }
 
 impl Drop for State {


### PR DESCRIPTION
cc @apiraino
closes #2 

@lu-zero is ok for get_quality to accept `&mut i32` instead of `usize`?
