### PR TITLE
add example-based test \cc @apiraino

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,9 @@ build = ["speexdsp-sys/build"]
 [dependencies]
 speexdsp-sys = { path = "speexdsp-sys" }
 
+[dev-dependencies]
+assert_cmd = "0.1.0"
+predicates = "0.4"
+
 [workspace]
 members = ["speexdsp-sys"]

--- a/tests/example.rs
+++ b/tests/example.rs
@@ -1,0 +1,14 @@
+extern crate assert_cmd;
+extern crate predicates;
+
+use std::process;
+
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+
+#[test]
+fn resample() {
+    let mut cmd = process::Command::cargo_example("testresample").unwrap();
+    let expected = String::from("Quality: 10\n").into_bytes();
+    cmd.assert().stdout(&predicate::eq(expected));
+}


### PR DESCRIPTION
depends on #1 
bese work for #1 use predicates to check stdout of the examples. Is not a strong testsuit, but at least keep tracks of working example.
