### PR TITLE
Add first tests

### DIFF
--- a/examples/testresample.rs
+++ b/examples/testresample.rs
@@ -12,16 +12,15 @@ fn main() {
     let mut off = 0;
     let mut avail = INBLOCK as isize;
 
-    let fin : Vec<f32> = (0 .. INBLOCK * 2).map(|i| ((i as f32) / PERIOD * 2.0 * PI).sin() * 0.9).collect();
+    let fin: Vec<f32> = (0..INBLOCK * 2)
+        .map(|i| ((i as f32) / PERIOD * 2.0 * PI).sin() * 0.9)
+        .collect();
     let mut fout = vec![0f32; INBLOCK * 4];
 
     let mut st = State::new(1, RATE, RATE, 4).unwrap();
 
     st.set_rate(RATE, rate);
     st.skip_zeros();
-
-    st.set_quality(10).unwrap();
-    eprintln!("Quality: {}", st.get_quality());
 
     loop {
         let in_len = avail as usize;
@@ -30,9 +29,13 @@ fn main() {
         let prev_in_len = in_len;
         let prev_out_len = out_len;
 
-        let (in_len, out_len) = st.process_float(0, &fin[off .. off + in_len], &mut fout[..out_len]).unwrap();
+        let (in_len, out_len) = st.process_float(0, &fin[off..off + in_len], &mut fout[..out_len])
+            .unwrap();
 
-        eprintln!("{} {} {} {} -> {} {}", rate, off, prev_in_len, prev_out_len, in_len, out_len);
+        eprintln!(
+            "{} {} {} {} -> {} {}",
+            rate, off, prev_in_len, prev_out_len, in_len, out_len
+        );
 
         off += in_len as usize;
         avail += INBLOCK as isize - in_len as isize;

--- a/examples/testresample.rs
+++ b/examples/testresample.rs
@@ -22,6 +22,9 @@ fn main() {
     st.set_rate(RATE, rate);
     st.skip_zeros();
 
+    st.set_quality(10).unwrap();
+    eprintln!("Quality: {}", st.get_quality());
+
     loop {
         let in_len = avail as usize;
         let out_len = (in_len * rate + RATE - 1) / RATE;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,23 +4,9 @@ pub mod resampler;
 
 #[cfg(test)]
 mod tests {
-    use resampler::State;
-    const RATE: usize = 48000;
-
     #[test]
-    fn test_quality() {
-        let st = State::new(1, RATE, RATE, 4).unwrap();
-        st.set_quality(10).unwrap();
-        assert_eq!(10, st.get_quality());
-    }
-
-    #[test]
-    fn test_rate() {
-        let mut st = State::new(1, RATE, RATE, 4).unwrap();
-        let expected_in_rate = 44100;
-        let expected_out_rate = 44000;
-        st.set_rate(expected_in_rate, expected_out_rate);
-        assert_eq!((expected_in_rate, expected_out_rate), st.get_rate());
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
     }
 
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,5 +8,4 @@ mod tests {
     fn it_works() {
         assert_eq!(2 + 2, 4);
     }
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,23 @@ pub mod resampler;
 
 #[cfg(test)]
 mod tests {
+    use resampler::State;
+    const RATE: usize = 48000;
+
     #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
+    fn test_quality() {
+        let st = State::new(1, RATE, RATE, 4).unwrap();
+        st.set_quality(10).unwrap();
+        assert_eq!(10, st.get_quality());
     }
+
+    #[test]
+    fn test_rate() {
+        let mut st = State::new(1, RATE, RATE, 4).unwrap();
+        let expected_in_rate = 44100;
+        let expected_out_rate = 44000;
+        st.set_rate(expected_in_rate, expected_out_rate);
+        assert_eq!((expected_in_rate, expected_out_rate), st.get_rate());
+    }
+
 }

--- a/src/resampler.rs
+++ b/src/resampler.rs
@@ -131,7 +131,6 @@ impl State {
         unsafe { speex_resampler_get_quality(self.st, &mut c_get) };
         c_get as usize
     }
-
 }
 
 impl Drop for State {

--- a/tests/resampler.rs
+++ b/tests/resampler.rs
@@ -3,14 +3,11 @@ extern crate speexdsp;
 #[cfg(test)]
 mod tests {
     use speexdsp::resampler::State;
-    const RATE: usize = 48000;
+    use std::f32::consts::PI;
 
-    #[test]
-    fn test_quality() {
-        let st = State::new(1, RATE, RATE, 4).unwrap();
-        st.set_quality(10).unwrap();
-        assert_eq!(10, st.get_quality());
-    }
+    const RATE: usize = 48000;
+    const INBLOCK: usize = 1024;
+    const PERIOD: f32 = 32f32;
 
     #[test]
     fn test_rate() {
@@ -19,6 +16,58 @@ mod tests {
         let expected_out_rate = 44000;
         st.set_rate(expected_in_rate, expected_out_rate);
         assert_eq!((expected_in_rate, expected_out_rate), st.get_rate());
+    }
+
+    #[test]
+    fn test_process_float() {
+        let mut st = State::new(1, RATE, RATE, 4).unwrap();
+        assert_eq!((1, 1), st.process_float(42, &[8.5], &mut [9.5]).unwrap());
+    }
+
+    #[test]
+    fn test_skip_zeros() {
+        let mut st = State::new(1, RATE, RATE, 4).unwrap();
+        let mut avail = INBLOCK as isize;
+        let mut rate = 1000;
+        let off = 0;
+        let fin: Vec<f32> = (0..INBLOCK * 2)
+            .map(|i| ((i as f32) / PERIOD * 2.0 * PI).sin() * 0.9)
+            .collect();
+        let mut fout = vec![0f32; INBLOCK * 4];
+        let in_len = avail as usize;
+        let out_len = (in_len * rate + RATE - 1) / RATE;
+        let f: f32 = 0.0;
+
+        // Don't skip first zero value
+        let (_, out_len) = st.process_float(0, &fin[off..off + in_len], &mut fout[..out_len])
+            .unwrap();
+        assert_eq!(&f, &fout[..out_len as usize][0]);
+
+        // skip first zero value
+        st.skip_zeros();
+        let (_, out_len) = st.process_float(0, &fin[off..off + in_len], &mut fout[..out_len])
+            .unwrap();
+        assert_ne!(&f, &fout[..out_len as usize][0]);
+    }
+
+    #[test]
+    fn test_latency() {
+        let mut quality = 2;
+        let mut st = State::new(1, RATE, RATE, quality).unwrap();
+        assert_eq!((quality * 8) as usize, st.get_input_latency());
+        assert_eq!((quality * 8) as usize, st.get_output_latency());
+
+        quality = 4;
+        st = State::new(1, RATE, RATE, quality).unwrap();
+        assert_eq!((quality * 8) as usize, st.get_input_latency());
+        assert_eq!((quality * 8) as usize, st.get_output_latency());
+    }
+
+    #[test]
+    fn test_quality() {
+        let st = State::new(1, RATE, RATE, 4).unwrap();
+        st.set_quality(10).unwrap();
+        assert_eq!(10, st.get_quality());
     }
 
 }

--- a/tests/resampler.rs
+++ b/tests/resampler.rs
@@ -1,0 +1,24 @@
+extern crate speexdsp;
+
+#[cfg(test)]
+mod tests {
+    use speexdsp::resampler::State;
+    const RATE: usize = 48000;
+
+    #[test]
+    fn test_quality() {
+        let st = State::new(1, RATE, RATE, 4).unwrap();
+        st.set_quality(10).unwrap();
+        assert_eq!(10, st.get_quality());
+    }
+
+    #[test]
+    fn test_rate() {
+        let mut st = State::new(1, RATE, RATE, 4).unwrap();
+        let expected_in_rate = 44100;
+        let expected_out_rate = 44000;
+        st.set_rate(expected_in_rate, expected_out_rate);
+        assert_eq!((expected_in_rate, expected_out_rate), st.get_rate());
+    }
+
+}


### PR DESCRIPTION
ok, here's what I think could be a way to implement real tests for the library APIs (https://github.com/rust-av/speexdsp-rs/issues/1).

Instead of "polluting" the source code files (something that it seems to be common pratice in Rust, but I'm still hesitant to do), could it make sense to keep them all together in `lib.rs`?

If this looks good, I'll go on covering all of the `State` APIs.

Let me know your thoughts, thanks for evaluating my patch!

cc @gibix 