### PR TITLE
Fix some errors

### DIFF
--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -5,6 +5,51 @@ mod sys {
     use std::fmt;
 
     #[derive(Clone, Copy, Debug)]
+    pub enum SpeexPreprocessConst {
+        SPEEX_PREPROCESS_SET_DENOISE = 0,
+        SPEEX_PREPROCESS_GET_DENOISE = 1,
+        SPEEX_PREPROCESS_SET_AGC = 2,
+        SPEEX_PREPROCESS_GET_AGC = 3,
+        SPEEX_PREPROCESS_SET_VAD = 4,
+        SPEEX_PREPROCESS_GET_VAD = 5,
+        SPEEX_PREPROCESS_SET_AGC_LEVEL = 6,
+        SPEEX_PREPROCESS_GET_AGC_LEVEL = 7,
+        SPEEX_PREPROCESS_SET_DEREVERB = 8,
+        SPEEX_PREPROCESS_GET_DEREVERB = 9,
+        SPEEX_PREPROCESS_SET_DEREVERB_LEVEL = 10,
+        SPEEX_PREPROCESS_GET_DEREVERB_LEVEL = 11,
+        SPEEX_PREPROCESS_SET_DEREVERB_DECAY = 12,
+        SPEEX_PREPROCESS_GET_DEREVERB_DECAY = 13,
+        SPEEX_PREPROCESS_SET_PROB_START = 14,
+        SPEEX_PREPROCESS_GET_PROB_START = 15,
+        SPEEX_PREPROCESS_SET_PROB_CONTINUE = 16,
+        SPEEX_PREPROCESS_GET_PROB_CONTINUE = 17,
+        SPEEX_PREPROCESS_SET_NOISE_SUPPRESS = 18,
+        SPEEX_PREPROCESS_GET_NOISE_SUPPRESS = 19,
+        SPEEX_PREPROCESS_SET_ECHO_SUPPRESS = 20,
+        SPEEX_PREPROCESS_GET_ECHO_SUPPRESS = 21,
+        SPEEX_PREPROCESS_SET_ECHO_SUPPRESS_ACTIVE = 22,
+        SPEEX_PREPROCESS_GET_ECHO_SUPPRESS_ACTIVE = 23,
+        SPEEX_PREPROCESS_SET_ECHO_STATE = 24,
+        SPEEX_PREPROCESS_GET_ECHO_STATE = 25,
+        SPEEX_PREPROCESS_SET_AGC_INCREMENT = 26,
+        SPEEX_PREPROCESS_GET_AGC_INCREMENT = 27,
+        SPEEX_PREPROCESS_SET_AGC_DECREMENT = 28,
+        SPEEX_PREPROCESS_GET_AGC_DECREMENT = 29,
+        SPEEX_PREPROCESS_SET_AGC_MAX_GAIN = 30,
+        SPEEX_PREPROCESS_GET_AGC_MAX_GAIN = 31,
+        SPEEX_PREPROCESS_GET_AGC_LOUDNESS = 33,
+        SPEEX_PREPROCESS_GET_AGC_GAIN = 35,
+        SPEEX_PREPROCESS_GET_PSD_SIZE = 37,
+        SPEEX_PREPROCESS_GET_PSD = 39,
+        SPEEX_PREPROCESS_GET_NOISE_PSD_SIZE = 41,
+        SPEEX_PREPROCESS_GET_NOISE_PSD = 43,
+        SPEEX_PREPROCESS_GET_PROB = 45,
+        SPEEX_PREPROCESS_SET_AGC_TARGET = 46,
+        SPEEX_PREPROCESS_GET_AGC_TARGET = 47,
+    }
+
+    #[derive(Clone, Copy, Debug)]
     pub enum Error {
         FailedInit,
     }
@@ -26,7 +71,7 @@ mod sys {
     impl SpeexPreprocess {
         pub fn new(
             frame_size: usize,
-            sampling_rate: usize,
+            sampling_rate: usize
         ) -> Result<Self, Error> {
             let st = unsafe {
                 speex_preprocess_state_init(
@@ -42,33 +87,32 @@ mod sys {
             }
         }
 
-        pub fn preprocess_run(&mut self, x: usize) -> usize {
-            unsafe {
-                speex_preprocess_run(self.st, x as *mut i16) as usize
-            }
+        pub fn preprocess_run(&mut self, x: &mut [i16]) -> usize {
+            unsafe { speex_preprocess_run(self.st, x.as_mut_ptr()) as usize }
         }
 
-        pub fn preprocess(&mut self, x: usize, echo: usize) -> usize {
+        pub fn preprocess(&mut self, x: &mut [i16], echo: usize) -> usize {
             unsafe {
                 speex_preprocess(
                     self.st,
-                    x as *mut i16,
-                    echo as *mut i32,
+                    x.as_mut_ptr(),
+                    echo as *mut i32
                 ) as usize
             }
         }
 
-        pub fn preprocess_estimate_update(&mut self, x: usize) {
+        pub fn preprocess_estimate_update(&mut self, x: &mut [i16]) {
             unsafe {
-                speex_preprocess_estimate_update(
-                    self.st,
-                    x as *mut i16,
-                )
+                speex_preprocess_estimate_update(self.st, x.as_mut_ptr())
             };
         }
 
-        pub fn preprocess_ctl(&mut self, request: usize, ptr: &mut f32) -> usize {
-            let ptr_v = ptr as *mut f32 as *mut c_void;
+        pub fn preprocess_ctl(
+            &mut self,
+            request: SpeexPreprocessConst,
+            mut ptr: f32
+        ) -> usize {
+            let ptr_v = (&mut ptr) as *mut f32 as *mut c_void;
             unsafe {
                 speex_preprocess_ctl(self.st, request as i32, ptr_v) as usize
             }
@@ -83,4 +127,4 @@ mod sys {
 }
 
 #[cfg(feature = "sys")]
-pub use self::sys::{Error, SpeexPreprocess};
+pub use self::sys::{Error, SpeexPreprocess, SpeexPreprocessConst};


### PR DESCRIPTION
- It is now possible to pass buffers to preprocess functions
- Defined the constants used by the `preprocess_ctl` function
- Some minor nits