### PR TITLE
Fix passing values to the preprocess_ctl function

### DIFF
--- a/examples/testdenoise.rs
+++ b/examples/testdenoise.rs
@@ -14,10 +14,10 @@ fn main() {
     let mut buffer: [u8; NN * 2] = [0; NN * 2];
 
     let mut st = SpeexPreprocess::new(NN, 8000).unwrap();
-    st.preprocess_ctl(SPEEX_PREPROCESS_SET_DENOISE, 1f32).unwrap();
-    st.preprocess_ctl(SPEEX_PREPROCESS_SET_AGC, 0f32).unwrap();
-    st.preprocess_ctl(SPEEX_PREPROCESS_SET_AGC_LEVEL, 8000f32).unwrap();
-    st.preprocess_ctl(SPEEX_PREPROCESS_SET_DEREVERB, 0f32).unwrap();
+    st.preprocess_ctl(SPEEX_PREPROCESS_SET_DENOISE, 1).unwrap();
+    st.preprocess_ctl(SPEEX_PREPROCESS_SET_AGC, 0).unwrap();
+    st.preprocess_ctl(SPEEX_PREPROCESS_SET_AGC_LEVEL, 8000).unwrap();
+    st.preprocess_ctl(SPEEX_PREPROCESS_SET_DEREVERB, 0).unwrap();
     st.preprocess_ctl(SPEEX_PREPROCESS_SET_DEREVERB_DECAY, 0f32).unwrap();
     st.preprocess_ctl(SPEEX_PREPROCESS_SET_DEREVERB_LEVEL, 0f32).unwrap();
 

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -109,12 +109,12 @@ mod sys {
             };
         }
 
-        pub fn preprocess_ctl(
+        pub fn preprocess_ctl<T>(
             &mut self,
             request: SpeexPreprocessConst,
-            mut ptr: f32
+            mut ptr: T
         ) -> Result<(), Error> {
-            let ptr_v = (&mut ptr) as *mut f32 as *mut c_void;
+            let ptr_v = (&mut ptr) as *mut T as *mut c_void;
             let ret = unsafe {
                 speex_preprocess_ctl(self.st, request as i32, ptr_v) as usize
             };


### PR DESCRIPTION
This PR allows the `preprocess_ctl` function to accept different types. 