### PR TITLE
Fix passing values to the preprocess_ctl function

### DIFF
--- a/examples/testdenoise.rs
+++ b/examples/testdenoise.rs
@@ -18,13 +18,10 @@ fn main() {
     let mut st = SpeexPreprocess::new(NN, 8000).unwrap();
     st.preprocess_ctl(SPEEX_PREPROCESS_SET_DENOISE, 1).unwrap();
     st.preprocess_ctl(SPEEX_PREPROCESS_SET_AGC, 0).unwrap();
-    st.preprocess_ctl(SPEEX_PREPROCESS_SET_AGC_LEVEL, 8000)
-        .unwrap();
+    st.preprocess_ctl(SPEEX_PREPROCESS_SET_AGC_LEVEL, 8000).unwrap();
     st.preprocess_ctl(SPEEX_PREPROCESS_SET_DEREVERB, 0).unwrap();
-    st.preprocess_ctl(SPEEX_PREPROCESS_SET_DEREVERB_DECAY, 0f32)
-        .unwrap();
-    st.preprocess_ctl(SPEEX_PREPROCESS_SET_DEREVERB_LEVEL, 0f32)
-        .unwrap();
+    st.preprocess_ctl(SPEEX_PREPROCESS_SET_DEREVERB_DECAY, 0f32).unwrap();
+    st.preprocess_ctl(SPEEX_PREPROCESS_SET_DEREVERB_LEVEL, 0f32).unwrap();
 
     while let Ok(n) = std::io::stdin().read(&mut buffer) {
         if n == 0 {

--- a/src/echo.rs
+++ b/src/echo.rs
@@ -30,6 +30,7 @@ mod sys {
         }
     }
 
+    #[derive(Clone)]
     pub struct SpeexEcho {
         st: *mut SpeexEchoState,
     }
@@ -111,6 +112,10 @@ mod sys {
             } else {
                 Ok(())
             }
+        }
+
+        pub(crate) fn get_ptr(&self) -> *mut SpeexEchoState {
+            self.st
         }
     }
 


### PR DESCRIPTION
This PR fixes how the `SpeexEcho` structure is passed to the `preprocess_ctl` function. This structure wraps the `SpeexEchoState` pointer that represents the correct value that should be passed to the `preprocess_ctl` function.

To achieve the goal, I had to differentiate the types through traits. I don't know if this is the right approach (I think not sincerly xD).  
At the beginning, I thought to use the @lu-zero  strategy, based on (key, type) pairs, but I would have made use of [this](https://doc.rust-lang.org/std/intrinsics/fn.type_name.html) nightly and unsafe function

Surely I missed the point here, if you could suggest a better approach for the problem, I'm happy to improve this PR :)

Thanks in advance!