### PR TITLE
replaced mem buffer reallocation with zeroing it

### DIFF
--- a/src/speex_resample.rs
+++ b/src/speex_resample.rs
@@ -636,11 +636,11 @@ impl SpeexResamplerState {
      */
     pub fn reset_mem(&mut self) {
         let nb_channels = self.nb_channels as usize;
-        self.last_sample = vec![0; nb_channels];
-        self.magic_samples = vec![0; nb_channels];
-        self.samp_frac_num = vec![0; nb_channels];
+        self.last_sample.iter_mut().for_each(|elem| *elem = 0);
+        self.magic_samples.iter_mut().for_each(|elem| *elem = 0);
+        self.samp_frac_num.iter_mut().for_each(|elem| *elem = 0);
 
-        self.mem = vec![0.0; nb_channels * (self.filt_len - 1) as usize];
+        self.mem.iter_mut().for_each(|elem| *elem = 0.);
     }
 
     #[inline]


### PR DESCRIPTION
I'm not sure if this is proper way to address #52 but it seems unnecessary to reallocate whole mem vec when you can just set each element to zero inside and reuse it again?