### PR TITLE
Removal of libc

### DIFF
--- a/fft/src/fftwrap.rs
+++ b/fft/src/fftwrap.rs
@@ -59,21 +59,21 @@ pub struct _IO_FILE {
 pub type _IO_lock_t = ();
 pub type FILE = _IO_FILE;
 /* *******************************************************************
- *                                                                  *
- * THIS FILE IS PART OF THE OggVorbis SOFTWARE CODEC SOURCE CODE.   *
- * USE, DISTRIBUTION AND REPRODUCTION OF THIS LIBRARY SOURCE IS     *
- * GOVERNED BY A BSD-STYLE SOURCE LICENSE INCLUDED WITH THIS SOURCE *
- * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
- *                                                                  *
- * THE OggVorbis SOURCE CODE IS (C) COPYRIGHT 1994-2001             *
- * by the XIPHOPHORUS Company http://www.xiph.org/                  *
- *                                                                  *
- ********************************************************************
+*                                                                  *
+* THIS FILE IS PART OF THE OggVorbis SOFTWARE CODEC SOURCE CODE.   *
+* USE, DISTRIBUTION AND REPRODUCTION OF THIS LIBRARY SOURCE IS     *
+* GOVERNED BY A BSD-STYLE SOURCE LICENSE INCLUDED WITH THIS SOURCE *
+* IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
+*                                                                  *
+* THE OggVorbis SOURCE CODE IS (C) COPYRIGHT 1994-2001             *
+* by the XIPHOPHORUS Company http://www.xiph.org/                  *
+*                                                                  *
+********************************************************************
 
- function: fft transform
- last mod: $Id: smallft.h,v 1.3 2003/09/16 18:35:45 jm Exp $
+function: fft transform
+last mod: $Id: smallft.h,v 1.3 2003/09/16 18:35:45 jm Exp $
 
- ********************************************************************/
+********************************************************************/
 /* *
    @file smallft.h
    @brief Discrete Rotational Fourier Transform (DRFT)
@@ -119,21 +119,26 @@ pub struct drft_lookup {
    POSSIBILITY OF SUCH DAMAGE.
 */
 /* * Speex wrapper for calloc. To do your own dynamic allocation, all you need to do is replace this function, speex_realloc and speex_free
-    NOTE: speex_alloc needs to CLEAR THE MEMORY */
+NOTE: speex_alloc needs to CLEAR THE MEMORY */
 #[inline]
 unsafe extern "C" fn speex_alloc(mut size: libc::c_int) -> *mut libc::c_void {
     /* WARNING: this is not equivalent to malloc(). If you want to use malloc()
-      or your own allocator, YOU NEED TO CLEAR THE MEMORY ALLOCATED. Otherwise
-      you will experience strange bugs */
+    or your own allocator, YOU NEED TO CLEAR THE MEMORY ALLOCATED. Otherwise
+    you will experience strange bugs */
     return calloc(size as libc::c_ulong, 1 as libc::c_int as libc::c_ulong);
 }
 /* * Speex wrapper for calloc. To do your own dynamic allocation, all you need to do is replace this function, speex_realloc and speex_alloc */
 #[inline]
-unsafe extern "C" fn speex_free(mut ptr: *mut libc::c_void) { free(ptr); }
+unsafe extern "C" fn speex_free(mut ptr: *mut libc::c_void) {
+    free(ptr);
+}
 #[inline]
 unsafe extern "C" fn speex_warning(mut str: *const libc::c_char) {
-    fprintf(stderr, b"warning: %s\n\x00" as *const u8 as *const libc::c_char,
-            str);
+    fprintf(
+        stderr,
+        b"warning: %s\n\x00" as *const u8 as *const libc::c_char,
+        str,
+    );
 }
 /* Copyright (C) 2005-2006 Jean-Marc Valin
    File: fftwrap.c
@@ -169,12 +174,10 @@ unsafe extern "C" fn speex_warning(mut str: *const libc::c_char) {
 
 */
 #[no_mangle]
-pub unsafe extern "C" fn spx_fft_init(mut size: libc::c_int)
- -> *mut libc::c_void {
+pub unsafe extern "C" fn spx_fft_init(mut size: libc::c_int) -> *mut libc::c_void {
     let mut table: *mut drft_lookup = 0 as *mut drft_lookup;
-    table =
-        speex_alloc(::std::mem::size_of::<drft_lookup>() as libc::c_ulong as
-                        libc::c_int) as *mut drft_lookup;
+    table = speex_alloc(::std::mem::size_of::<drft_lookup>() as libc::c_ulong as libc::c_int)
+        as *mut drft_lookup;
     spx_drft_init(table, size);
     return table as *mut libc::c_void;
 }
@@ -184,16 +187,16 @@ pub unsafe extern "C" fn spx_fft_destroy(mut table: *mut libc::c_void) {
     speex_free(table);
 }
 #[no_mangle]
-pub unsafe extern "C" fn spx_fft(mut table: *mut libc::c_void,
-                                 mut in_0: *mut libc::c_float,
-                                 mut out: *mut libc::c_float) {
+pub unsafe extern "C" fn spx_fft(
+    mut table: *mut libc::c_void,
+    mut in_0: *mut libc::c_float,
+    mut out: *mut libc::c_float,
+) {
     if in_0 == out {
         let mut i: libc::c_int = 0;
         let mut scale: libc::c_float =
-            (1.0f64 / (*(table as *mut drft_lookup)).n as libc::c_double) as
-                libc::c_float;
-        speex_warning(b"FFT should not be done in-place\x00" as *const u8 as
-                          *const libc::c_char);
+            (1.0f64 / (*(table as *mut drft_lookup)).n as libc::c_double) as libc::c_float;
+        speex_warning(b"FFT should not be done in-place\x00" as *const u8 as *const libc::c_char);
         i = 0 as libc::c_int;
         while i < (*(table as *mut drft_lookup)).n {
             *out.offset(i as isize) = scale * *in_0.offset(i as isize);
@@ -202,8 +205,7 @@ pub unsafe extern "C" fn spx_fft(mut table: *mut libc::c_void,
     } else {
         let mut i_0: libc::c_int = 0;
         let mut scale_0: libc::c_float =
-            (1.0f64 / (*(table as *mut drft_lookup)).n as libc::c_double) as
-                libc::c_float;
+            (1.0f64 / (*(table as *mut drft_lookup)).n as libc::c_double) as libc::c_float;
         i_0 = 0 as libc::c_int;
         while i_0 < (*(table as *mut drft_lookup)).n {
             *out.offset(i_0 as isize) = scale_0 * *in_0.offset(i_0 as isize);
@@ -213,12 +215,13 @@ pub unsafe extern "C" fn spx_fft(mut table: *mut libc::c_void,
     spx_drft_forward(table as *mut drft_lookup, out);
 }
 #[no_mangle]
-pub unsafe extern "C" fn spx_ifft(mut table: *mut libc::c_void,
-                                  mut in_0: *mut libc::c_float,
-                                  mut out: *mut libc::c_float) {
+pub unsafe extern "C" fn spx_ifft(
+    mut table: *mut libc::c_void,
+    mut in_0: *mut libc::c_float,
+    mut out: *mut libc::c_float,
+) {
     if in_0 == out {
-        speex_warning(b"FFT should not be done in-place\x00" as *const u8 as
-                          *const libc::c_char);
+        speex_warning(b"FFT should not be done in-place\x00" as *const u8 as *const libc::c_char);
     } else {
         let mut i: libc::c_int = 0;
         i = 0 as libc::c_int;
@@ -230,14 +233,18 @@ pub unsafe extern "C" fn spx_ifft(mut table: *mut libc::c_void,
     spx_drft_backward(table as *mut drft_lookup, out);
 }
 #[no_mangle]
-pub unsafe extern "C" fn spx_fft_float(mut table: *mut libc::c_void,
-                                       mut in_0: *mut libc::c_float,
-                                       mut out: *mut libc::c_float) {
+pub unsafe extern "C" fn spx_fft_float(
+    mut table: *mut libc::c_void,
+    mut in_0: *mut libc::c_float,
+    mut out: *mut libc::c_float,
+) {
     spx_fft(table, in_0, out);
 }
 #[no_mangle]
-pub unsafe extern "C" fn spx_ifft_float(mut table: *mut libc::c_void,
-                                        mut in_0: *mut libc::c_float,
-                                        mut out: *mut libc::c_float) {
+pub unsafe extern "C" fn spx_ifft_float(
+    mut table: *mut libc::c_void,
+    mut in_0: *mut libc::c_float,
+    mut out: *mut libc::c_float,
+) {
     spx_ifft(table, in_0, out);
 }

--- a/fft/src/fftwrap.rs
+++ b/fft/src/fftwrap.rs
@@ -1,5 +1,18 @@
-#![allow(dead_code, mutable_transmutes, non_camel_case_types, non_snake_case,
-         non_upper_case_globals, unused_assignments, unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+
+use std::{
+    ffi::c_void,
+    os::raw::{c_char, c_double, c_float, c_int, c_long, c_schar, c_ulong, c_ushort},
+};
+
 extern "C" {
     pub type _IO_wide_data;
     pub type _IO_codecvt;
@@ -7,54 +20,54 @@ extern "C" {
     #[no_mangle]
     static mut stderr: *mut FILE;
     #[no_mangle]
-    fn fprintf(_: *mut FILE, _: *const libc::c_char, _: ...) -> libc::c_int;
+    fn fprintf(_: *mut FILE, _: *const c_char, _: ...) -> c_int;
     #[no_mangle]
-    fn calloc(_: libc::c_ulong, _: libc::c_ulong) -> *mut libc::c_void;
+    fn calloc(_: c_ulong, _: c_ulong) -> *mut c_void;
     #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
+    fn free(__ptr: *mut c_void);
     #[no_mangle]
-    fn spx_drft_forward(l: *mut drft_lookup, data: *mut libc::c_float);
+    fn spx_drft_forward(l: *mut drft_lookup, data: *mut c_float);
     #[no_mangle]
-    fn spx_drft_backward(l: *mut drft_lookup, data: *mut libc::c_float);
+    fn spx_drft_backward(l: *mut drft_lookup, data: *mut c_float);
     #[no_mangle]
-    fn spx_drft_init(l: *mut drft_lookup, n: libc::c_int);
+    fn spx_drft_init(l: *mut drft_lookup, n: c_int);
     #[no_mangle]
     fn spx_drft_clear(l: *mut drft_lookup);
 }
-pub type __off_t = libc::c_long;
-pub type __off64_t = libc::c_long;
+pub type __off_t = c_long;
+pub type __off64_t = c_long;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct _IO_FILE {
-    pub _flags: libc::c_int,
-    pub _IO_read_ptr: *mut libc::c_char,
-    pub _IO_read_end: *mut libc::c_char,
-    pub _IO_read_base: *mut libc::c_char,
-    pub _IO_write_base: *mut libc::c_char,
-    pub _IO_write_ptr: *mut libc::c_char,
-    pub _IO_write_end: *mut libc::c_char,
-    pub _IO_buf_base: *mut libc::c_char,
-    pub _IO_buf_end: *mut libc::c_char,
-    pub _IO_save_base: *mut libc::c_char,
-    pub _IO_backup_base: *mut libc::c_char,
-    pub _IO_save_end: *mut libc::c_char,
+    pub _flags: c_int,
+    pub _IO_read_ptr: *mut c_char,
+    pub _IO_read_end: *mut c_char,
+    pub _IO_read_base: *mut c_char,
+    pub _IO_write_base: *mut c_char,
+    pub _IO_write_ptr: *mut c_char,
+    pub _IO_write_end: *mut c_char,
+    pub _IO_buf_base: *mut c_char,
+    pub _IO_buf_end: *mut c_char,
+    pub _IO_save_base: *mut c_char,
+    pub _IO_backup_base: *mut c_char,
+    pub _IO_save_end: *mut c_char,
     pub _markers: *mut _IO_marker,
     pub _chain: *mut _IO_FILE,
-    pub _fileno: libc::c_int,
-    pub _flags2: libc::c_int,
+    pub _fileno: c_int,
+    pub _flags2: c_int,
     pub _old_offset: __off_t,
-    pub _cur_column: libc::c_ushort,
-    pub _vtable_offset: libc::c_schar,
-    pub _shortbuf: [libc::c_char; 1],
-    pub _lock: *mut libc::c_void,
+    pub _cur_column: c_ushort,
+    pub _vtable_offset: c_schar,
+    pub _shortbuf: [c_char; 1],
+    pub _lock: *mut c_void,
     pub _offset: __off64_t,
     pub _codecvt: *mut _IO_codecvt,
     pub _wide_data: *mut _IO_wide_data,
     pub _freeres_list: *mut _IO_FILE,
-    pub _freeres_buf: *mut libc::c_void,
-    pub __pad5: libc::c_int,
-    pub _mode: libc::c_int,
-    pub _unused2: libc::c_char,
+    pub _freeres_buf: *mut c_void,
+    pub __pad5: c_int,
+    pub _mode: c_int,
+    pub _unused2: c_char,
 }
 pub type _IO_lock_t = ();
 pub type FILE = _IO_FILE;
@@ -82,9 +95,9 @@ last mod: $Id: smallft.h,v 1.3 2003/09/16 18:35:45 jm Exp $
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct drft_lookup {
-    pub n: libc::c_int,
-    pub trigcache: *mut libc::c_float,
-    pub splitcache: *mut libc::c_int,
+    pub n: c_int,
+    pub trigcache: *mut c_float,
+    pub splitcache: *mut c_int,
 }
 /* Copyright (C) 2007 Jean-Marc Valin
 
@@ -121,22 +134,22 @@ pub struct drft_lookup {
 /* * Speex wrapper for calloc. To do your own dynamic allocation, all you need to do is replace this function, speex_realloc and speex_free
 NOTE: speex_alloc needs to CLEAR THE MEMORY */
 #[inline]
-unsafe extern "C" fn speex_alloc(mut size: libc::c_int) -> *mut libc::c_void {
+unsafe extern "C" fn speex_alloc(mut size: c_int) -> *mut c_void {
     /* WARNING: this is not equivalent to malloc(). If you want to use malloc()
     or your own allocator, YOU NEED TO CLEAR THE MEMORY ALLOCATED. Otherwise
     you will experience strange bugs */
-    return calloc(size as libc::c_ulong, 1 as libc::c_int as libc::c_ulong);
+    return calloc(size as c_ulong, 1 as c_int as c_ulong);
 }
 /* * Speex wrapper for calloc. To do your own dynamic allocation, all you need to do is replace this function, speex_realloc and speex_alloc */
 #[inline]
-unsafe extern "C" fn speex_free(mut ptr: *mut libc::c_void) {
+unsafe extern "C" fn speex_free(mut ptr: *mut c_void) {
     free(ptr);
 }
 #[inline]
-unsafe extern "C" fn speex_warning(mut str: *const libc::c_char) {
+unsafe extern "C" fn speex_warning(mut str: *const c_char) {
     fprintf(
         stderr,
-        b"warning: %s\n\x00" as *const u8 as *const libc::c_char,
+        b"warning: %s\n\x00" as *const u8 as *const c_char,
         str,
     );
 }
@@ -174,39 +187,38 @@ unsafe extern "C" fn speex_warning(mut str: *const libc::c_char) {
 
 */
 #[no_mangle]
-pub unsafe extern "C" fn spx_fft_init(mut size: libc::c_int) -> *mut libc::c_void {
+pub unsafe extern "C" fn spx_fft_init(mut size: c_int) -> *mut c_void {
     let mut table: *mut drft_lookup = 0 as *mut drft_lookup;
-    table = speex_alloc(::std::mem::size_of::<drft_lookup>() as libc::c_ulong as libc::c_int)
-        as *mut drft_lookup;
+    table =
+        speex_alloc(::std::mem::size_of::<drft_lookup>() as c_ulong as c_int) as *mut drft_lookup;
     spx_drft_init(table, size);
-    return table as *mut libc::c_void;
+    return table as *mut c_void;
 }
 #[no_mangle]
-pub unsafe extern "C" fn spx_fft_destroy(mut table: *mut libc::c_void) {
+pub unsafe extern "C" fn spx_fft_destroy(mut table: *mut c_void) {
     spx_drft_clear(table as *mut drft_lookup);
     speex_free(table);
 }
 #[no_mangle]
 pub unsafe extern "C" fn spx_fft(
-    mut table: *mut libc::c_void,
-    mut in_0: *mut libc::c_float,
-    mut out: *mut libc::c_float,
+    mut table: *mut c_void,
+    mut in_0: *mut c_float,
+    mut out: *mut c_float,
 ) {
     if in_0 == out {
-        let mut i: libc::c_int = 0;
-        let mut scale: libc::c_float =
-            (1.0f64 / (*(table as *mut drft_lookup)).n as libc::c_double) as libc::c_float;
-        speex_warning(b"FFT should not be done in-place\x00" as *const u8 as *const libc::c_char);
-        i = 0 as libc::c_int;
+        let mut i: c_int = 0;
+        let mut scale: c_float = (1.0f64 / (*(table as *mut drft_lookup)).n as c_double) as c_float;
+        speex_warning(b"FFT should not be done in-place\x00" as *const u8 as *const c_char);
+        i = 0 as c_int;
         while i < (*(table as *mut drft_lookup)).n {
             *out.offset(i as isize) = scale * *in_0.offset(i as isize);
             i += 1
         }
     } else {
-        let mut i_0: libc::c_int = 0;
-        let mut scale_0: libc::c_float =
-            (1.0f64 / (*(table as *mut drft_lookup)).n as libc::c_double) as libc::c_float;
-        i_0 = 0 as libc::c_int;
+        let mut i_0: c_int = 0;
+        let mut scale_0: c_float =
+            (1.0f64 / (*(table as *mut drft_lookup)).n as c_double) as c_float;
+        i_0 = 0 as c_int;
         while i_0 < (*(table as *mut drft_lookup)).n {
             *out.offset(i_0 as isize) = scale_0 * *in_0.offset(i_0 as isize);
             i_0 += 1
@@ -216,15 +228,15 @@ pub unsafe extern "C" fn spx_fft(
 }
 #[no_mangle]
 pub unsafe extern "C" fn spx_ifft(
-    mut table: *mut libc::c_void,
-    mut in_0: *mut libc::c_float,
-    mut out: *mut libc::c_float,
+    mut table: *mut c_void,
+    mut in_0: *mut c_float,
+    mut out: *mut c_float,
 ) {
     if in_0 == out {
-        speex_warning(b"FFT should not be done in-place\x00" as *const u8 as *const libc::c_char);
+        speex_warning(b"FFT should not be done in-place\x00" as *const u8 as *const c_char);
     } else {
-        let mut i: libc::c_int = 0;
-        i = 0 as libc::c_int;
+        let mut i: c_int = 0;
+        i = 0 as c_int;
         while i < (*(table as *mut drft_lookup)).n {
             *out.offset(i as isize) = *in_0.offset(i as isize);
             i += 1
@@ -234,17 +246,17 @@ pub unsafe extern "C" fn spx_ifft(
 }
 #[no_mangle]
 pub unsafe extern "C" fn spx_fft_float(
-    mut table: *mut libc::c_void,
-    mut in_0: *mut libc::c_float,
-    mut out: *mut libc::c_float,
+    mut table: *mut c_void,
+    mut in_0: *mut c_float,
+    mut out: *mut c_float,
 ) {
     spx_fft(table, in_0, out);
 }
 #[no_mangle]
 pub unsafe extern "C" fn spx_ifft_float(
-    mut table: *mut libc::c_void,
-    mut in_0: *mut libc::c_float,
-    mut out: *mut libc::c_float,
+    mut table: *mut c_void,
+    mut in_0: *mut c_float,
+    mut out: *mut c_float,
 ) {
     spx_ifft(table, in_0, out);
 }

--- a/fft/src/lib.rs
+++ b/fft/src/lib.rs
@@ -1,7 +1,6 @@
 #![feature(const_raw_ptr_to_usize_cast, extern_types, register_tool)]
 
-mod smallft;
 mod fftwrap;
+mod smallft;
 
 pub use crate::fftwrap::*;
-

--- a/fft/src/smallft.rs
+++ b/fft/src/smallft.rs
@@ -1,14 +1,27 @@
-#![allow(dead_code, mutable_transmutes, non_camel_case_types, non_snake_case,
-         non_upper_case_globals, unused_assignments, unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+
+use std::{
+    ffi::c_void,
+    os::raw::{c_double, c_float, c_int, c_ulong},
+};
+
 extern "C" {
     #[no_mangle]
-    fn cos(_: libc::c_double) -> libc::c_double;
+    fn cos(_: c_double) -> c_double;
     #[no_mangle]
-    fn sin(_: libc::c_double) -> libc::c_double;
+    fn sin(_: c_double) -> c_double;
     #[no_mangle]
-    fn calloc(_: libc::c_ulong, _: libc::c_ulong) -> *mut libc::c_void;
+    fn calloc(_: c_ulong, _: c_ulong) -> *mut c_void;
     #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
+    fn free(__ptr: *mut c_void);
 }
 /* *******************************************************************
 *                                                                  *
@@ -34,16 +47,16 @@ last mod: $Id: smallft.h,v 1.3 2003/09/16 18:35:45 jm Exp $
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct drft_lookup {
-    pub n: libc::c_int,
-    pub trigcache: *mut libc::c_float,
-    pub splitcache: *mut libc::c_int,
+    pub n: c_int,
+    pub trigcache: *mut c_float,
+    pub splitcache: *mut c_int,
 }
 #[inline]
-unsafe extern "C" fn speex_alloc(mut size: libc::c_int) -> *mut libc::c_void {
-    return calloc(size as libc::c_ulong, 1 as libc::c_int as libc::c_ulong);
+unsafe extern "C" fn speex_alloc(mut size: c_int) -> *mut c_void {
+    return calloc(size as c_ulong, 1 as c_int as c_ulong);
 }
 #[inline]
-unsafe extern "C" fn speex_free(mut ptr: *mut libc::c_void) {
+unsafe extern "C" fn speex_free(mut ptr: *mut c_void) {
     free(ptr);
 }
 /* *******************************************************************
@@ -74,105 +87,96 @@ last mod: $Id: smallft.c,v 1.19 2003/10/08 05:12:37 jm Exp $
  * it follows R_0, R_1, I_1, R_2, I_2 ... R_n-1, I_n-1, I_n like the
  * FORTRAN version
  */
-unsafe extern "C" fn drfti1(
-    mut n: libc::c_int,
-    mut wa: *mut libc::c_float,
-    mut ifac: *mut libc::c_int,
-) {
-    static mut ntryh: [libc::c_int; 4] = [
-        4 as libc::c_int,
-        2 as libc::c_int,
-        3 as libc::c_int,
-        5 as libc::c_int,
-    ];
-    static mut tpi: libc::c_float = 6.28318530717958648f32;
-    let mut arg: libc::c_float = 0.;
-    let mut argh: libc::c_float = 0.;
-    let mut argld: libc::c_float = 0.;
-    let mut fi: libc::c_float = 0.;
-    let mut ntry: libc::c_int = 0 as libc::c_int;
-    let mut i: libc::c_int = 0;
-    let mut j: libc::c_int = -(1 as libc::c_int);
-    let mut k1: libc::c_int = 0;
-    let mut l1: libc::c_int = 0;
-    let mut l2: libc::c_int = 0;
-    let mut ib: libc::c_int = 0;
-    let mut ld: libc::c_int = 0;
-    let mut ii: libc::c_int = 0;
-    let mut ip: libc::c_int = 0;
-    let mut is: libc::c_int = 0;
-    let mut nq: libc::c_int = 0;
-    let mut nr: libc::c_int = 0;
-    let mut ido: libc::c_int = 0;
-    let mut ipm: libc::c_int = 0;
-    let mut nfm1: libc::c_int = 0;
-    let mut nl: libc::c_int = n;
-    let mut nf: libc::c_int = 0 as libc::c_int;
+unsafe extern "C" fn drfti1(mut n: c_int, mut wa: *mut c_float, mut ifac: *mut c_int) {
+    static mut ntryh: [c_int; 4] = [4 as c_int, 2 as c_int, 3 as c_int, 5 as c_int];
+    static mut tpi: c_float = 6.28318530717958648f32;
+    let mut arg: c_float = 0.;
+    let mut argh: c_float = 0.;
+    let mut argld: c_float = 0.;
+    let mut fi: c_float = 0.;
+    let mut ntry: c_int = 0 as c_int;
+    let mut i: c_int = 0;
+    let mut j: c_int = -(1 as c_int);
+    let mut k1: c_int = 0;
+    let mut l1: c_int = 0;
+    let mut l2: c_int = 0;
+    let mut ib: c_int = 0;
+    let mut ld: c_int = 0;
+    let mut ii: c_int = 0;
+    let mut ip: c_int = 0;
+    let mut is: c_int = 0;
+    let mut nq: c_int = 0;
+    let mut nr: c_int = 0;
+    let mut ido: c_int = 0;
+    let mut ipm: c_int = 0;
+    let mut nfm1: c_int = 0;
+    let mut nl: c_int = n;
+    let mut nf: c_int = 0 as c_int;
     'c_10244: loop {
         j += 1;
-        if j < 4 as libc::c_int {
+        if j < 4 as c_int {
             ntry = ntryh[j as usize]
         } else {
-            ntry += 2 as libc::c_int
+            ntry += 2 as c_int
         }
         loop {
             nq = nl / ntry;
             nr = nl - ntry * nq;
-            if nr != 0 as libc::c_int {
+            if nr != 0 as c_int {
                 break;
             }
             nf += 1;
-            *ifac.offset((nf + 1 as libc::c_int) as isize) = ntry;
+            *ifac.offset((nf + 1 as c_int) as isize) = ntry;
             nl = nq;
-            if !(ntry != 2 as libc::c_int) {
-                if !(nf == 1 as libc::c_int) {
-                    i = 1 as libc::c_int;
+            if !(ntry != 2 as c_int) {
+                if !(nf == 1 as c_int) {
+                    i = 1 as c_int;
                     while i < nf {
-                        ib = nf - i + 1 as libc::c_int;
-                        *ifac.offset((ib + 1 as libc::c_int) as isize) = *ifac.offset(ib as isize);
+                        ib = nf - i + 1 as c_int;
+                        *ifac.offset((ib + 1 as c_int) as isize) = *ifac.offset(ib as isize);
                         i += 1
                     }
-                    *ifac.offset(2 as libc::c_int as isize) = 2 as libc::c_int
+                    *ifac.offset(2 as c_int as isize) = 2 as c_int
                 }
             }
-            if !(nl != 1 as libc::c_int) {
+            if !(nl != 1 as c_int) {
                 break 'c_10244;
             }
         }
     }
-    *ifac.offset(0 as libc::c_int as isize) = n;
-    *ifac.offset(1 as libc::c_int as isize) = nf;
-    argh = tpi / n as libc::c_float;
-    is = 0 as libc::c_int;
-    nfm1 = nf - 1 as libc::c_int;
-    l1 = 1 as libc::c_int;
-    if nfm1 == 0 as libc::c_int {
+    *ifac.offset(0 as c_int as isize) = n;
+    *ifac.offset(1 as c_int as isize) = nf;
+    argh = tpi / n as c_float;
+    is = 0 as c_int;
+    nfm1 = nf - 1 as c_int;
+    l1 = 1 as c_int;
+    if nfm1 == 0 as c_int {
         return;
     }
-    k1 = 0 as libc::c_int;
+    k1 = 0 as c_int;
     while k1 < nfm1 {
-        ip = *ifac.offset((k1 + 2 as libc::c_int) as isize);
-        ld = 0 as libc::c_int;
+        ip = *ifac.offset((k1 + 2 as c_int) as isize);
+        ld = 0 as c_int;
         l2 = l1 * ip;
         ido = n / l2;
-        ipm = ip - 1 as libc::c_int;
-        j = 0 as libc::c_int;
+        ipm = ip - 1 as c_int;
+        j = 0 as c_int;
         while j < ipm {
             ld += l1;
             i = is;
-            argld = ld as libc::c_float * argh;
+            argld = ld as c_float * argh;
             fi = 0.0f32;
-            ii = 2 as libc::c_int;
+            ii = 2 as c_int;
             while ii < ido {
                 fi += 1.0f32;
                 arg = fi * argld;
                 let fresh0 = i;
                 i = i + 1;
-                *wa.offset(fresh0 as isize) = cos(arg as libc::c_double) as libc::c_float;
+                *wa.offset(fresh0 as isize) = cos(arg as c_double) as c_float;
                 let fresh1 = i;
                 i = i + 1;
-                *wa.offset(fresh1 as isize) = sin(arg as libc::c_double) as libc::c_float;
-                ii += 2 as libc::c_int
+                *wa.offset(fresh1 as isize) = sin(arg as c_double) as c_float;
+                ii += 2 as c_int
             }
             is += ido;
             j += 1
@@ -181,150 +185,144 @@ unsafe extern "C" fn drfti1(
         k1 += 1
     }
 }
-unsafe extern "C" fn fdrffti(
-    mut n: libc::c_int,
-    mut wsave: *mut libc::c_float,
-    mut ifac: *mut libc::c_int,
-) {
-    if n == 1 as libc::c_int {
+unsafe extern "C" fn fdrffti(mut n: c_int, mut wsave: *mut c_float, mut ifac: *mut c_int) {
+    if n == 1 as c_int {
         return;
     }
     drfti1(n, wsave.offset(n as isize), ifac);
 }
 unsafe extern "C" fn dradf2(
-    mut ido: libc::c_int,
-    mut l1: libc::c_int,
-    mut cc: *mut libc::c_float,
-    mut ch: *mut libc::c_float,
-    mut wa1: *mut libc::c_float,
+    mut ido: c_int,
+    mut l1: c_int,
+    mut cc: *mut c_float,
+    mut ch: *mut c_float,
+    mut wa1: *mut c_float,
 ) {
-    let mut i: libc::c_int = 0;
-    let mut k: libc::c_int = 0;
-    let mut ti2: libc::c_float = 0.;
-    let mut tr2: libc::c_float = 0.;
-    let mut t0: libc::c_int = 0;
-    let mut t1: libc::c_int = 0;
-    let mut t2: libc::c_int = 0;
-    let mut t3: libc::c_int = 0;
-    let mut t4: libc::c_int = 0;
-    let mut t5: libc::c_int = 0;
-    let mut t6: libc::c_int = 0;
-    t1 = 0 as libc::c_int;
+    let mut i: c_int = 0;
+    let mut k: c_int = 0;
+    let mut ti2: c_float = 0.;
+    let mut tr2: c_float = 0.;
+    let mut t0: c_int = 0;
+    let mut t1: c_int = 0;
+    let mut t2: c_int = 0;
+    let mut t3: c_int = 0;
+    let mut t4: c_int = 0;
+    let mut t5: c_int = 0;
+    let mut t6: c_int = 0;
+    t1 = 0 as c_int;
     t2 = l1 * ido;
     t0 = t2;
-    t3 = ido << 1 as libc::c_int;
-    k = 0 as libc::c_int;
+    t3 = ido << 1 as c_int;
+    k = 0 as c_int;
     while k < l1 {
-        *ch.offset((t1 << 1 as libc::c_int) as isize) =
-            *cc.offset(t1 as isize) + *cc.offset(t2 as isize);
-        *ch.offset(((t1 << 1 as libc::c_int) + t3 - 1 as libc::c_int) as isize) =
+        *ch.offset((t1 << 1 as c_int) as isize) = *cc.offset(t1 as isize) + *cc.offset(t2 as isize);
+        *ch.offset(((t1 << 1 as c_int) + t3 - 1 as c_int) as isize) =
             *cc.offset(t1 as isize) - *cc.offset(t2 as isize);
         t1 += ido;
         t2 += ido;
         k += 1
     }
-    if ido < 2 as libc::c_int {
+    if ido < 2 as c_int {
         return;
     }
-    if !(ido == 2 as libc::c_int) {
-        t1 = 0 as libc::c_int;
+    if !(ido == 2 as c_int) {
+        t1 = 0 as c_int;
         t2 = t0;
-        k = 0 as libc::c_int;
+        k = 0 as c_int;
         while k < l1 {
             t3 = t2;
-            t4 = (t1 << 1 as libc::c_int) + (ido << 1 as libc::c_int);
+            t4 = (t1 << 1 as c_int) + (ido << 1 as c_int);
             t5 = t1;
             t6 = t1 + t1;
-            i = 2 as libc::c_int;
+            i = 2 as c_int;
             while i < ido {
-                t3 += 2 as libc::c_int;
-                t4 -= 2 as libc::c_int;
-                t5 += 2 as libc::c_int;
-                t6 += 2 as libc::c_int;
-                tr2 = *wa1.offset((i - 2 as libc::c_int) as isize)
-                    * *cc.offset((t3 - 1 as libc::c_int) as isize)
-                    + *wa1.offset((i - 1 as libc::c_int) as isize) * *cc.offset(t3 as isize);
-                ti2 = *wa1.offset((i - 2 as libc::c_int) as isize) * *cc.offset(t3 as isize)
-                    - *wa1.offset((i - 1 as libc::c_int) as isize)
-                        * *cc.offset((t3 - 1 as libc::c_int) as isize);
+                t3 += 2 as c_int;
+                t4 -= 2 as c_int;
+                t5 += 2 as c_int;
+                t6 += 2 as c_int;
+                tr2 = *wa1.offset((i - 2 as c_int) as isize)
+                    * *cc.offset((t3 - 1 as c_int) as isize)
+                    + *wa1.offset((i - 1 as c_int) as isize) * *cc.offset(t3 as isize);
+                ti2 = *wa1.offset((i - 2 as c_int) as isize) * *cc.offset(t3 as isize)
+                    - *wa1.offset((i - 1 as c_int) as isize)
+                        * *cc.offset((t3 - 1 as c_int) as isize);
                 *ch.offset(t6 as isize) = *cc.offset(t5 as isize) + ti2;
                 *ch.offset(t4 as isize) = ti2 - *cc.offset(t5 as isize);
-                *ch.offset((t6 - 1 as libc::c_int) as isize) =
-                    *cc.offset((t5 - 1 as libc::c_int) as isize) + tr2;
-                *ch.offset((t4 - 1 as libc::c_int) as isize) =
-                    *cc.offset((t5 - 1 as libc::c_int) as isize) - tr2;
-                i += 2 as libc::c_int
+                *ch.offset((t6 - 1 as c_int) as isize) =
+                    *cc.offset((t5 - 1 as c_int) as isize) + tr2;
+                *ch.offset((t4 - 1 as c_int) as isize) =
+                    *cc.offset((t5 - 1 as c_int) as isize) - tr2;
+                i += 2 as c_int
             }
             t1 += ido;
             t2 += ido;
             k += 1
         }
-        if ido % 2 as libc::c_int == 1 as libc::c_int {
+        if ido % 2 as c_int == 1 as c_int {
             return;
         }
     }
     t1 = ido;
-    t2 = t1 - 1 as libc::c_int;
+    t2 = t1 - 1 as c_int;
     t3 = t2;
     t2 += t0;
-    k = 0 as libc::c_int;
+    k = 0 as c_int;
     while k < l1 {
         *ch.offset(t1 as isize) = -*cc.offset(t2 as isize);
-        *ch.offset((t1 - 1 as libc::c_int) as isize) = *cc.offset(t3 as isize);
-        t1 += ido << 1 as libc::c_int;
+        *ch.offset((t1 - 1 as c_int) as isize) = *cc.offset(t3 as isize);
+        t1 += ido << 1 as c_int;
         t2 += ido;
         t3 += ido;
         k += 1
     }
 }
 unsafe extern "C" fn dradf4(
-    mut ido: libc::c_int,
-    mut l1: libc::c_int,
-    mut cc: *mut libc::c_float,
-    mut ch: *mut libc::c_float,
-    mut wa1: *mut libc::c_float,
-    mut wa2: *mut libc::c_float,
-    mut wa3: *mut libc::c_float,
+    mut ido: c_int,
+    mut l1: c_int,
+    mut cc: *mut c_float,
+    mut ch: *mut c_float,
+    mut wa1: *mut c_float,
+    mut wa2: *mut c_float,
+    mut wa3: *mut c_float,
 ) {
-    static mut hsqt2: libc::c_float = 0.70710678118654752f32;
-    let mut i: libc::c_int = 0;
-    let mut k: libc::c_int = 0;
-    let mut t0: libc::c_int = 0;
-    let mut t1: libc::c_int = 0;
-    let mut t2: libc::c_int = 0;
-    let mut t3: libc::c_int = 0;
-    let mut t4: libc::c_int = 0;
-    let mut t5: libc::c_int = 0;
-    let mut t6: libc::c_int = 0;
-    let mut ci2: libc::c_float = 0.;
-    let mut ci3: libc::c_float = 0.;
-    let mut ci4: libc::c_float = 0.;
-    let mut cr2: libc::c_float = 0.;
-    let mut cr3: libc::c_float = 0.;
-    let mut cr4: libc::c_float = 0.;
-    let mut ti1: libc::c_float = 0.;
-    let mut ti2: libc::c_float = 0.;
-    let mut ti3: libc::c_float = 0.;
-    let mut ti4: libc::c_float = 0.;
-    let mut tr1: libc::c_float = 0.;
-    let mut tr2: libc::c_float = 0.;
-    let mut tr3: libc::c_float = 0.;
-    let mut tr4: libc::c_float = 0.;
+    static mut hsqt2: c_float = 0.70710678118654752f32;
+    let mut i: c_int = 0;
+    let mut k: c_int = 0;
+    let mut t0: c_int = 0;
+    let mut t1: c_int = 0;
+    let mut t2: c_int = 0;
+    let mut t3: c_int = 0;
+    let mut t4: c_int = 0;
+    let mut t5: c_int = 0;
+    let mut t6: c_int = 0;
+    let mut ci2: c_float = 0.;
+    let mut ci3: c_float = 0.;
+    let mut ci4: c_float = 0.;
+    let mut cr2: c_float = 0.;
+    let mut cr3: c_float = 0.;
+    let mut cr4: c_float = 0.;
+    let mut ti1: c_float = 0.;
+    let mut ti2: c_float = 0.;
+    let mut ti3: c_float = 0.;
+    let mut ti4: c_float = 0.;
+    let mut tr1: c_float = 0.;
+    let mut tr2: c_float = 0.;
+    let mut tr3: c_float = 0.;
+    let mut tr4: c_float = 0.;
     t0 = l1 * ido;
     t1 = t0;
-    t4 = t1 << 1 as libc::c_int;
-    t2 = t1 + (t1 << 1 as libc::c_int);
-    t3 = 0 as libc::c_int;
-    k = 0 as libc::c_int;
+    t4 = t1 << 1 as c_int;
+    t2 = t1 + (t1 << 1 as c_int);
+    t3 = 0 as c_int;
+    k = 0 as c_int;
     while k < l1 {
         tr1 = *cc.offset(t1 as isize) + *cc.offset(t2 as isize);
         tr2 = *cc.offset(t3 as isize) + *cc.offset(t4 as isize);
-        t5 = t3 << 2 as libc::c_int;
+        t5 = t3 << 2 as c_int;
         *ch.offset(t5 as isize) = tr1 + tr2;
-        *ch.offset(((ido << 2 as libc::c_int) + t5 - 1 as libc::c_int) as isize) = tr2 - tr1;
-        t5 += ido << 1 as libc::c_int;
-        *ch.offset((t5 - 1 as libc::c_int) as isize) =
-            *cc.offset(t3 as isize) - *cc.offset(t4 as isize);
+        *ch.offset(((ido << 2 as c_int) + t5 - 1 as c_int) as isize) = tr2 - tr1;
+        t5 += ido << 1 as c_int;
+        *ch.offset((t5 - 1 as c_int) as isize) = *cc.offset(t3 as isize) - *cc.offset(t4 as isize);
         *ch.offset(t5 as isize) = *cc.offset(t2 as isize) - *cc.offset(t1 as isize);
         t1 += ido;
         t2 += ido;
@@ -332,83 +330,81 @@ unsafe extern "C" fn dradf4(
         t4 += ido;
         k += 1
     }
-    if ido < 2 as libc::c_int {
+    if ido < 2 as c_int {
         return;
     }
-    if !(ido == 2 as libc::c_int) {
-        t1 = 0 as libc::c_int;
-        k = 0 as libc::c_int;
+    if !(ido == 2 as c_int) {
+        t1 = 0 as c_int;
+        k = 0 as c_int;
         while k < l1 {
             t2 = t1;
-            t4 = t1 << 2 as libc::c_int;
-            t6 = ido << 1 as libc::c_int;
+            t4 = t1 << 2 as c_int;
+            t6 = ido << 1 as c_int;
             t5 = t6 + t4;
-            i = 2 as libc::c_int;
+            i = 2 as c_int;
             while i < ido {
-                t2 += 2 as libc::c_int;
+                t2 += 2 as c_int;
                 t3 = t2;
-                t4 += 2 as libc::c_int;
-                t5 -= 2 as libc::c_int;
+                t4 += 2 as c_int;
+                t5 -= 2 as c_int;
                 t3 += t0;
-                cr2 = *wa1.offset((i - 2 as libc::c_int) as isize)
-                    * *cc.offset((t3 - 1 as libc::c_int) as isize)
-                    + *wa1.offset((i - 1 as libc::c_int) as isize) * *cc.offset(t3 as isize);
-                ci2 = *wa1.offset((i - 2 as libc::c_int) as isize) * *cc.offset(t3 as isize)
-                    - *wa1.offset((i - 1 as libc::c_int) as isize)
-                        * *cc.offset((t3 - 1 as libc::c_int) as isize);
+                cr2 = *wa1.offset((i - 2 as c_int) as isize)
+                    * *cc.offset((t3 - 1 as c_int) as isize)
+                    + *wa1.offset((i - 1 as c_int) as isize) * *cc.offset(t3 as isize);
+                ci2 = *wa1.offset((i - 2 as c_int) as isize) * *cc.offset(t3 as isize)
+                    - *wa1.offset((i - 1 as c_int) as isize)
+                        * *cc.offset((t3 - 1 as c_int) as isize);
                 t3 += t0;
-                cr3 = *wa2.offset((i - 2 as libc::c_int) as isize)
-                    * *cc.offset((t3 - 1 as libc::c_int) as isize)
-                    + *wa2.offset((i - 1 as libc::c_int) as isize) * *cc.offset(t3 as isize);
-                ci3 = *wa2.offset((i - 2 as libc::c_int) as isize) * *cc.offset(t3 as isize)
-                    - *wa2.offset((i - 1 as libc::c_int) as isize)
-                        * *cc.offset((t3 - 1 as libc::c_int) as isize);
+                cr3 = *wa2.offset((i - 2 as c_int) as isize)
+                    * *cc.offset((t3 - 1 as c_int) as isize)
+                    + *wa2.offset((i - 1 as c_int) as isize) * *cc.offset(t3 as isize);
+                ci3 = *wa2.offset((i - 2 as c_int) as isize) * *cc.offset(t3 as isize)
+                    - *wa2.offset((i - 1 as c_int) as isize)
+                        * *cc.offset((t3 - 1 as c_int) as isize);
                 t3 += t0;
-                cr4 = *wa3.offset((i - 2 as libc::c_int) as isize)
-                    * *cc.offset((t3 - 1 as libc::c_int) as isize)
-                    + *wa3.offset((i - 1 as libc::c_int) as isize) * *cc.offset(t3 as isize);
-                ci4 = *wa3.offset((i - 2 as libc::c_int) as isize) * *cc.offset(t3 as isize)
-                    - *wa3.offset((i - 1 as libc::c_int) as isize)
-                        * *cc.offset((t3 - 1 as libc::c_int) as isize);
+                cr4 = *wa3.offset((i - 2 as c_int) as isize)
+                    * *cc.offset((t3 - 1 as c_int) as isize)
+                    + *wa3.offset((i - 1 as c_int) as isize) * *cc.offset(t3 as isize);
+                ci4 = *wa3.offset((i - 2 as c_int) as isize) * *cc.offset(t3 as isize)
+                    - *wa3.offset((i - 1 as c_int) as isize)
+                        * *cc.offset((t3 - 1 as c_int) as isize);
                 tr1 = cr2 + cr4;
                 tr4 = cr4 - cr2;
                 ti1 = ci2 + ci4;
                 ti4 = ci2 - ci4;
                 ti2 = *cc.offset(t2 as isize) + ci3;
                 ti3 = *cc.offset(t2 as isize) - ci3;
-                tr2 = *cc.offset((t2 - 1 as libc::c_int) as isize) + cr3;
-                tr3 = *cc.offset((t2 - 1 as libc::c_int) as isize) - cr3;
-                *ch.offset((t4 - 1 as libc::c_int) as isize) = tr1 + tr2;
+                tr2 = *cc.offset((t2 - 1 as c_int) as isize) + cr3;
+                tr3 = *cc.offset((t2 - 1 as c_int) as isize) - cr3;
+                *ch.offset((t4 - 1 as c_int) as isize) = tr1 + tr2;
                 *ch.offset(t4 as isize) = ti1 + ti2;
-                *ch.offset((t5 - 1 as libc::c_int) as isize) = tr3 - ti4;
+                *ch.offset((t5 - 1 as c_int) as isize) = tr3 - ti4;
                 *ch.offset(t5 as isize) = tr4 - ti3;
-                *ch.offset((t4 + t6 - 1 as libc::c_int) as isize) = ti4 + tr3;
+                *ch.offset((t4 + t6 - 1 as c_int) as isize) = ti4 + tr3;
                 *ch.offset((t4 + t6) as isize) = tr4 + ti3;
-                *ch.offset((t5 + t6 - 1 as libc::c_int) as isize) = tr2 - tr1;
+                *ch.offset((t5 + t6 - 1 as c_int) as isize) = tr2 - tr1;
                 *ch.offset((t5 + t6) as isize) = ti1 - ti2;
-                i += 2 as libc::c_int
+                i += 2 as c_int
             }
             t1 += ido;
             k += 1
         }
-        if ido & 1 as libc::c_int != 0 {
+        if ido & 1 as c_int != 0 {
             return;
         }
     }
-    t1 = t0 + ido - 1 as libc::c_int;
-    t2 = t1 + (t0 << 1 as libc::c_int);
-    t3 = ido << 2 as libc::c_int;
+    t1 = t0 + ido - 1 as c_int;
+    t2 = t1 + (t0 << 1 as c_int);
+    t3 = ido << 2 as c_int;
     t4 = ido;
-    t5 = ido << 1 as libc::c_int;
+    t5 = ido << 1 as c_int;
     t6 = ido;
-    k = 0 as libc::c_int;
+    k = 0 as c_int;
     while k < l1 {
         ti1 = -hsqt2 * (*cc.offset(t1 as isize) + *cc.offset(t2 as isize));
         tr1 = hsqt2 * (*cc.offset(t1 as isize) - *cc.offset(t2 as isize));
-        *ch.offset((t4 - 1 as libc::c_int) as isize) =
-            tr1 + *cc.offset((t6 - 1 as libc::c_int) as isize);
-        *ch.offset((t4 + t5 - 1 as libc::c_int) as isize) =
-            *cc.offset((t6 - 1 as libc::c_int) as isize) - tr1;
+        *ch.offset((t4 - 1 as c_int) as isize) = tr1 + *cc.offset((t6 - 1 as c_int) as isize);
+        *ch.offset((t4 + t5 - 1 as c_int) as isize) = *cc.offset((t6 - 1 as c_int) as isize) - tr1;
         *ch.offset(t4 as isize) = ti1 - *cc.offset((t1 + t0) as isize);
         *ch.offset((t4 + t5) as isize) = ti1 + *cc.offset((t1 + t0) as isize);
         t1 += ido;
@@ -419,73 +415,73 @@ unsafe extern "C" fn dradf4(
     }
 }
 unsafe extern "C" fn dradfg(
-    mut ido: libc::c_int,
-    mut ip: libc::c_int,
-    mut l1: libc::c_int,
-    mut idl1: libc::c_int,
-    mut cc: *mut libc::c_float,
-    mut c1: *mut libc::c_float,
-    mut c2: *mut libc::c_float,
-    mut ch: *mut libc::c_float,
-    mut ch2: *mut libc::c_float,
-    mut wa: *mut libc::c_float,
+    mut ido: c_int,
+    mut ip: c_int,
+    mut l1: c_int,
+    mut idl1: c_int,
+    mut cc: *mut c_float,
+    mut c1: *mut c_float,
+    mut c2: *mut c_float,
+    mut ch: *mut c_float,
+    mut ch2: *mut c_float,
+    mut wa: *mut c_float,
 ) {
-    static mut tpi: libc::c_float = 6.283185307179586f32;
-    let mut idij: libc::c_int = 0;
-    let mut ipph: libc::c_int = 0;
-    let mut i: libc::c_int = 0;
-    let mut j: libc::c_int = 0;
-    let mut k: libc::c_int = 0;
-    let mut l: libc::c_int = 0;
-    let mut ic: libc::c_int = 0;
-    let mut ik: libc::c_int = 0;
-    let mut is: libc::c_int = 0;
-    let mut t0: libc::c_int = 0;
-    let mut t1: libc::c_int = 0;
-    let mut t2: libc::c_int = 0;
-    let mut t3: libc::c_int = 0;
-    let mut t4: libc::c_int = 0;
-    let mut t5: libc::c_int = 0;
-    let mut t6: libc::c_int = 0;
-    let mut t7: libc::c_int = 0;
-    let mut t8: libc::c_int = 0;
-    let mut t9: libc::c_int = 0;
-    let mut t10: libc::c_int = 0;
-    let mut dc2: libc::c_float = 0.;
-    let mut ai1: libc::c_float = 0.;
-    let mut ai2: libc::c_float = 0.;
-    let mut ar1: libc::c_float = 0.;
-    let mut ar2: libc::c_float = 0.;
-    let mut ds2: libc::c_float = 0.;
-    let mut nbd: libc::c_int = 0;
-    let mut dcp: libc::c_float = 0.;
-    let mut arg: libc::c_float = 0.;
-    let mut dsp: libc::c_float = 0.;
-    let mut ar1h: libc::c_float = 0.;
-    let mut ar2h: libc::c_float = 0.;
-    let mut idp2: libc::c_int = 0;
-    let mut ipp2: libc::c_int = 0;
-    arg = tpi / ip as libc::c_float;
-    dcp = cos(arg as libc::c_double) as libc::c_float;
-    dsp = sin(arg as libc::c_double) as libc::c_float;
-    ipph = ip + 1 as libc::c_int >> 1 as libc::c_int;
+    static mut tpi: c_float = 6.283185307179586f32;
+    let mut idij: c_int = 0;
+    let mut ipph: c_int = 0;
+    let mut i: c_int = 0;
+    let mut j: c_int = 0;
+    let mut k: c_int = 0;
+    let mut l: c_int = 0;
+    let mut ic: c_int = 0;
+    let mut ik: c_int = 0;
+    let mut is: c_int = 0;
+    let mut t0: c_int = 0;
+    let mut t1: c_int = 0;
+    let mut t2: c_int = 0;
+    let mut t3: c_int = 0;
+    let mut t4: c_int = 0;
+    let mut t5: c_int = 0;
+    let mut t6: c_int = 0;
+    let mut t7: c_int = 0;
+    let mut t8: c_int = 0;
+    let mut t9: c_int = 0;
+    let mut t10: c_int = 0;
+    let mut dc2: c_float = 0.;
+    let mut ai1: c_float = 0.;
+    let mut ai2: c_float = 0.;
+    let mut ar1: c_float = 0.;
+    let mut ar2: c_float = 0.;
+    let mut ds2: c_float = 0.;
+    let mut nbd: c_int = 0;
+    let mut dcp: c_float = 0.;
+    let mut arg: c_float = 0.;
+    let mut dsp: c_float = 0.;
+    let mut ar1h: c_float = 0.;
+    let mut ar2h: c_float = 0.;
+    let mut idp2: c_int = 0;
+    let mut ipp2: c_int = 0;
+    arg = tpi / ip as c_float;
+    dcp = cos(arg as c_double) as c_float;
+    dsp = sin(arg as c_double) as c_float;
+    ipph = ip + 1 as c_int >> 1 as c_int;
     ipp2 = ip;
     idp2 = ido;
-    nbd = ido - 1 as libc::c_int >> 1 as libc::c_int;
+    nbd = ido - 1 as c_int >> 1 as c_int;
     t0 = l1 * ido;
     t10 = ip * ido;
-    if !(ido == 1 as libc::c_int) {
-        ik = 0 as libc::c_int;
+    if !(ido == 1 as c_int) {
+        ik = 0 as c_int;
         while ik < idl1 {
             *ch2.offset(ik as isize) = *c2.offset(ik as isize);
             ik += 1
         }
-        t1 = 0 as libc::c_int;
-        j = 1 as libc::c_int;
+        t1 = 0 as c_int;
+        j = 1 as c_int;
         while j < ip {
             t1 += t0;
             t2 = t1;
-            k = 0 as libc::c_int;
+            k = 0 as c_int;
             while k < l1 {
                 *ch.offset(t2 as isize) = *c1.offset(t2 as isize);
                 t2 += ido;
@@ -494,123 +490,121 @@ unsafe extern "C" fn dradfg(
             j += 1
         }
         is = -ido;
-        t1 = 0 as libc::c_int;
+        t1 = 0 as c_int;
         if nbd > l1 {
-            j = 1 as libc::c_int;
+            j = 1 as c_int;
             while j < ip {
                 t1 += t0;
                 is += ido;
                 t2 = -ido + t1;
-                k = 0 as libc::c_int;
+                k = 0 as c_int;
                 while k < l1 {
-                    idij = is - 1 as libc::c_int;
+                    idij = is - 1 as c_int;
                     t2 += ido;
                     t3 = t2;
-                    i = 2 as libc::c_int;
+                    i = 2 as c_int;
                     while i < ido {
-                        idij += 2 as libc::c_int;
-                        t3 += 2 as libc::c_int;
-                        *ch.offset((t3 - 1 as libc::c_int) as isize) = *wa
-                            .offset((idij - 1 as libc::c_int) as isize)
-                            * *c1.offset((t3 - 1 as libc::c_int) as isize)
+                        idij += 2 as c_int;
+                        t3 += 2 as c_int;
+                        *ch.offset((t3 - 1 as c_int) as isize) = *wa
+                            .offset((idij - 1 as c_int) as isize)
+                            * *c1.offset((t3 - 1 as c_int) as isize)
                             + *wa.offset(idij as isize) * *c1.offset(t3 as isize);
-                        *ch.offset(t3 as isize) = *wa.offset((idij - 1 as libc::c_int) as isize)
+                        *ch.offset(t3 as isize) = *wa.offset((idij - 1 as c_int) as isize)
                             * *c1.offset(t3 as isize)
-                            - *wa.offset(idij as isize)
-                                * *c1.offset((t3 - 1 as libc::c_int) as isize);
-                        i += 2 as libc::c_int
+                            - *wa.offset(idij as isize) * *c1.offset((t3 - 1 as c_int) as isize);
+                        i += 2 as c_int
                     }
                     k += 1
                 }
                 j += 1
             }
         } else {
-            j = 1 as libc::c_int;
+            j = 1 as c_int;
             while j < ip {
                 is += ido;
-                idij = is - 1 as libc::c_int;
+                idij = is - 1 as c_int;
                 t1 += t0;
                 t2 = t1;
-                i = 2 as libc::c_int;
+                i = 2 as c_int;
                 while i < ido {
-                    idij += 2 as libc::c_int;
-                    t2 += 2 as libc::c_int;
+                    idij += 2 as c_int;
+                    t2 += 2 as c_int;
                     t3 = t2;
-                    k = 0 as libc::c_int;
+                    k = 0 as c_int;
                     while k < l1 {
-                        *ch.offset((t3 - 1 as libc::c_int) as isize) = *wa
-                            .offset((idij - 1 as libc::c_int) as isize)
-                            * *c1.offset((t3 - 1 as libc::c_int) as isize)
+                        *ch.offset((t3 - 1 as c_int) as isize) = *wa
+                            .offset((idij - 1 as c_int) as isize)
+                            * *c1.offset((t3 - 1 as c_int) as isize)
                             + *wa.offset(idij as isize) * *c1.offset(t3 as isize);
-                        *ch.offset(t3 as isize) = *wa.offset((idij - 1 as libc::c_int) as isize)
+                        *ch.offset(t3 as isize) = *wa.offset((idij - 1 as c_int) as isize)
                             * *c1.offset(t3 as isize)
-                            - *wa.offset(idij as isize)
-                                * *c1.offset((t3 - 1 as libc::c_int) as isize);
+                            - *wa.offset(idij as isize) * *c1.offset((t3 - 1 as c_int) as isize);
                         t3 += ido;
                         k += 1
                     }
-                    i += 2 as libc::c_int
+                    i += 2 as c_int
                 }
                 j += 1
             }
         }
-        t1 = 0 as libc::c_int;
+        t1 = 0 as c_int;
         t2 = ipp2 * t0;
         if nbd < l1 {
-            j = 1 as libc::c_int;
+            j = 1 as c_int;
             while j < ipph {
                 t1 += t0;
                 t2 -= t0;
                 t3 = t1;
                 t4 = t2;
-                i = 2 as libc::c_int;
+                i = 2 as c_int;
                 while i < ido {
-                    t3 += 2 as libc::c_int;
-                    t4 += 2 as libc::c_int;
+                    t3 += 2 as c_int;
+                    t4 += 2 as c_int;
                     t5 = t3 - ido;
                     t6 = t4 - ido;
-                    k = 0 as libc::c_int;
+                    k = 0 as c_int;
                     while k < l1 {
                         t5 += ido;
                         t6 += ido;
-                        *c1.offset((t5 - 1 as libc::c_int) as isize) = *ch
-                            .offset((t5 - 1 as libc::c_int) as isize)
-                            + *ch.offset((t6 - 1 as libc::c_int) as isize);
-                        *c1.offset((t6 - 1 as libc::c_int) as isize) =
+                        *c1.offset((t5 - 1 as c_int) as isize) = *ch
+                            .offset((t5 - 1 as c_int) as isize)
+                            + *ch.offset((t6 - 1 as c_int) as isize);
+                        *c1.offset((t6 - 1 as c_int) as isize) =
                             *ch.offset(t5 as isize) - *ch.offset(t6 as isize);
                         *c1.offset(t5 as isize) = *ch.offset(t5 as isize) + *ch.offset(t6 as isize);
-                        *c1.offset(t6 as isize) = *ch.offset((t6 - 1 as libc::c_int) as isize)
-                            - *ch.offset((t5 - 1 as libc::c_int) as isize);
+                        *c1.offset(t6 as isize) = *ch.offset((t6 - 1 as c_int) as isize)
+                            - *ch.offset((t5 - 1 as c_int) as isize);
                         k += 1
                     }
-                    i += 2 as libc::c_int
+                    i += 2 as c_int
                 }
                 j += 1
             }
         } else {
-            j = 1 as libc::c_int;
+            j = 1 as c_int;
             while j < ipph {
                 t1 += t0;
                 t2 -= t0;
                 t3 = t1;
                 t4 = t2;
-                k = 0 as libc::c_int;
+                k = 0 as c_int;
                 while k < l1 {
                     t5 = t3;
                     t6 = t4;
-                    i = 2 as libc::c_int;
+                    i = 2 as c_int;
                     while i < ido {
-                        t5 += 2 as libc::c_int;
-                        t6 += 2 as libc::c_int;
-                        *c1.offset((t5 - 1 as libc::c_int) as isize) = *ch
-                            .offset((t5 - 1 as libc::c_int) as isize)
-                            + *ch.offset((t6 - 1 as libc::c_int) as isize);
-                        *c1.offset((t6 - 1 as libc::c_int) as isize) =
+                        t5 += 2 as c_int;
+                        t6 += 2 as c_int;
+                        *c1.offset((t5 - 1 as c_int) as isize) = *ch
+                            .offset((t5 - 1 as c_int) as isize)
+                            + *ch.offset((t6 - 1 as c_int) as isize);
+                        *c1.offset((t6 - 1 as c_int) as isize) =
                             *ch.offset(t5 as isize) - *ch.offset(t6 as isize);
                         *c1.offset(t5 as isize) = *ch.offset(t5 as isize) + *ch.offset(t6 as isize);
-                        *c1.offset(t6 as isize) = *ch.offset((t6 - 1 as libc::c_int) as isize)
-                            - *ch.offset((t5 - 1 as libc::c_int) as isize);
-                        i += 2 as libc::c_int
+                        *c1.offset(t6 as isize) = *ch.offset((t6 - 1 as c_int) as isize)
+                            - *ch.offset((t5 - 1 as c_int) as isize);
+                        i += 2 as c_int
                     }
                     t3 += ido;
                     t4 += ido;
@@ -620,20 +614,20 @@ unsafe extern "C" fn dradfg(
             }
         }
     }
-    ik = 0 as libc::c_int;
+    ik = 0 as c_int;
     while ik < idl1 {
         *c2.offset(ik as isize) = *ch2.offset(ik as isize);
         ik += 1
     }
-    t1 = 0 as libc::c_int;
+    t1 = 0 as c_int;
     t2 = ipp2 * idl1;
-    j = 1 as libc::c_int;
+    j = 1 as c_int;
     while j < ipph {
         t1 += t0;
         t2 -= t0;
         t3 = t1 - ido;
         t4 = t2 - ido;
-        k = 0 as libc::c_int;
+        k = 0 as c_int;
         while k < l1 {
             t3 += ido;
             t4 += ido;
@@ -645,10 +639,10 @@ unsafe extern "C" fn dradfg(
     }
     ar1 = 1.0f32;
     ai1 = 0.0f32;
-    t1 = 0 as libc::c_int;
+    t1 = 0 as c_int;
     t2 = ipp2 * idl1;
-    t3 = (ip - 1 as libc::c_int) * idl1;
-    l = 1 as libc::c_int;
+    t3 = (ip - 1 as c_int) * idl1;
+    l = 1 as c_int;
     while l < ipph {
         t1 += idl1;
         t2 -= idl1;
@@ -659,7 +653,7 @@ unsafe extern "C" fn dradfg(
         t5 = t2;
         t6 = t3;
         t7 = idl1;
-        ik = 0 as libc::c_int;
+        ik = 0 as c_int;
         while ik < idl1 {
             let fresh2 = t7;
             t7 = t7 + 1;
@@ -679,8 +673,8 @@ unsafe extern "C" fn dradfg(
         ar2 = ar1;
         ai2 = ai1;
         t4 = idl1;
-        t5 = (ipp2 - 1 as libc::c_int) * idl1;
-        j = 2 as libc::c_int;
+        t5 = (ipp2 - 1 as c_int) * idl1;
+        j = 2 as c_int;
         while j < ipph {
             t4 += idl1;
             t5 -= idl1;
@@ -691,7 +685,7 @@ unsafe extern "C" fn dradfg(
             t7 = t2;
             t8 = t4;
             t9 = t5;
-            ik = 0 as libc::c_int;
+            ik = 0 as c_int;
             while ik < idl1 {
                 let fresh6 = t8;
                 t8 = t8 + 1;
@@ -709,12 +703,12 @@ unsafe extern "C" fn dradfg(
         }
         l += 1
     }
-    t1 = 0 as libc::c_int;
-    j = 1 as libc::c_int;
+    t1 = 0 as c_int;
+    j = 1 as c_int;
     while j < ipph {
         t1 += idl1;
         t2 = t1;
-        ik = 0 as libc::c_int;
+        ik = 0 as c_int;
         while ik < idl1 {
             let fresh10 = t2;
             t2 = t2 + 1;
@@ -724,11 +718,11 @@ unsafe extern "C" fn dradfg(
         j += 1
     }
     if ido < l1 {
-        i = 0 as libc::c_int;
+        i = 0 as c_int;
         while i < ido {
             t1 = i;
             t2 = i;
-            k = 0 as libc::c_int;
+            k = 0 as c_int;
             while k < l1 {
                 *cc.offset(t2 as isize) = *ch.offset(t1 as isize);
                 t1 += ido;
@@ -738,13 +732,13 @@ unsafe extern "C" fn dradfg(
             i += 1
         }
     } else {
-        t1 = 0 as libc::c_int;
-        t2 = 0 as libc::c_int;
-        k = 0 as libc::c_int;
+        t1 = 0 as c_int;
+        t2 = 0 as c_int;
+        k = 0 as c_int;
         while k < l1 {
             t3 = t1;
             t4 = t2;
-            i = 0 as libc::c_int;
+            i = 0 as c_int;
             while i < ido {
                 let fresh11 = t3;
                 t3 = t3 + 1;
@@ -758,11 +752,11 @@ unsafe extern "C" fn dradfg(
             k += 1
         }
     }
-    t1 = 0 as libc::c_int;
-    t2 = ido << 1 as libc::c_int;
-    t3 = 0 as libc::c_int;
+    t1 = 0 as c_int;
+    t2 = ido << 1 as c_int;
+    t3 = 0 as c_int;
     t4 = ipp2 * t0;
-    j = 1 as libc::c_int;
+    j = 1 as c_int;
     while j < ipph {
         t1 += t2;
         t3 += t0;
@@ -770,9 +764,9 @@ unsafe extern "C" fn dradfg(
         t5 = t1;
         t6 = t3;
         t7 = t4;
-        k = 0 as libc::c_int;
+        k = 0 as c_int;
         while k < l1 {
-            *cc.offset((t5 - 1 as libc::c_int) as isize) = *ch.offset(t6 as isize);
+            *cc.offset((t5 - 1 as c_int) as isize) = *ch.offset(t6 as isize);
             *cc.offset(t5 as isize) = *ch.offset(t7 as isize);
             t5 += t10;
             t6 += ido;
@@ -781,34 +775,32 @@ unsafe extern "C" fn dradfg(
         }
         j += 1
     }
-    if ido == 1 as libc::c_int {
+    if ido == 1 as c_int {
         return;
     }
     if nbd < l1 {
         t1 = -ido;
-        t3 = 0 as libc::c_int;
-        t4 = 0 as libc::c_int;
+        t3 = 0 as c_int;
+        t4 = 0 as c_int;
         t5 = ipp2 * t0;
-        j = 1 as libc::c_int;
+        j = 1 as c_int;
         while j < ipph {
             t1 += t2;
             t3 += t2;
             t4 += t0;
             t5 -= t0;
-            i = 2 as libc::c_int;
+            i = 2 as c_int;
             while i < ido {
                 t6 = idp2 + t1 - i;
                 t7 = i + t3;
                 t8 = i + t4;
                 t9 = i + t5;
-                k = 0 as libc::c_int;
+                k = 0 as c_int;
                 while k < l1 {
-                    *cc.offset((t7 - 1 as libc::c_int) as isize) = *ch
-                        .offset((t8 - 1 as libc::c_int) as isize)
-                        + *ch.offset((t9 - 1 as libc::c_int) as isize);
-                    *cc.offset((t6 - 1 as libc::c_int) as isize) = *ch
-                        .offset((t8 - 1 as libc::c_int) as isize)
-                        - *ch.offset((t9 - 1 as libc::c_int) as isize);
+                    *cc.offset((t7 - 1 as c_int) as isize) = *ch.offset((t8 - 1 as c_int) as isize)
+                        + *ch.offset((t9 - 1 as c_int) as isize);
+                    *cc.offset((t6 - 1 as c_int) as isize) = *ch.offset((t8 - 1 as c_int) as isize)
+                        - *ch.offset((t9 - 1 as c_int) as isize);
                     *cc.offset(t7 as isize) = *ch.offset(t8 as isize) + *ch.offset(t9 as isize);
                     *cc.offset(t6 as isize) = *ch.offset(t9 as isize) - *ch.offset(t8 as isize);
                     t6 += t10;
@@ -817,17 +809,17 @@ unsafe extern "C" fn dradfg(
                     t9 += ido;
                     k += 1
                 }
-                i += 2 as libc::c_int
+                i += 2 as c_int
             }
             j += 1
         }
         return;
     } else {
         t1 = -ido;
-        t3 = 0 as libc::c_int;
-        t4 = 0 as libc::c_int;
+        t3 = 0 as c_int;
+        t4 = 0 as c_int;
         t5 = ipp2 * t0;
-        j = 1 as libc::c_int;
+        j = 1 as c_int;
         while j < ipph {
             t1 += t2;
             t3 += t2;
@@ -837,22 +829,22 @@ unsafe extern "C" fn dradfg(
             t7 = t3;
             t8 = t4;
             t9 = t5;
-            k = 0 as libc::c_int;
+            k = 0 as c_int;
             while k < l1 {
-                i = 2 as libc::c_int;
+                i = 2 as c_int;
                 while i < ido {
                     ic = idp2 - i;
-                    *cc.offset((i + t7 - 1 as libc::c_int) as isize) = *ch
-                        .offset((i + t8 - 1 as libc::c_int) as isize)
-                        + *ch.offset((i + t9 - 1 as libc::c_int) as isize);
-                    *cc.offset((ic + t6 - 1 as libc::c_int) as isize) = *ch
-                        .offset((i + t8 - 1 as libc::c_int) as isize)
-                        - *ch.offset((i + t9 - 1 as libc::c_int) as isize);
+                    *cc.offset((i + t7 - 1 as c_int) as isize) = *ch
+                        .offset((i + t8 - 1 as c_int) as isize)
+                        + *ch.offset((i + t9 - 1 as c_int) as isize);
+                    *cc.offset((ic + t6 - 1 as c_int) as isize) = *ch
+                        .offset((i + t8 - 1 as c_int) as isize)
+                        - *ch.offset((i + t9 - 1 as c_int) as isize);
                     *cc.offset((i + t7) as isize) =
                         *ch.offset((i + t8) as isize) + *ch.offset((i + t9) as isize);
                     *cc.offset((ic + t6) as isize) =
                         *ch.offset((i + t9) as isize) - *ch.offset((i + t8) as isize);
-                    i += 2 as libc::c_int
+                    i += 2 as c_int
                 }
                 t6 += t10;
                 t7 += t10;
@@ -866,44 +858,44 @@ unsafe extern "C" fn dradfg(
     };
 }
 unsafe extern "C" fn drftf1(
-    mut n: libc::c_int,
-    mut c: *mut libc::c_float,
-    mut ch: *mut libc::c_float,
-    mut wa: *mut libc::c_float,
-    mut ifac: *mut libc::c_int,
+    mut n: c_int,
+    mut c: *mut c_float,
+    mut ch: *mut c_float,
+    mut wa: *mut c_float,
+    mut ifac: *mut c_int,
 ) {
-    let mut i: libc::c_int = 0;
-    let mut k1: libc::c_int = 0;
-    let mut l1: libc::c_int = 0;
-    let mut l2: libc::c_int = 0;
-    let mut na: libc::c_int = 0;
-    let mut kh: libc::c_int = 0;
-    let mut nf: libc::c_int = 0;
-    let mut ip: libc::c_int = 0;
-    let mut iw: libc::c_int = 0;
-    let mut ido: libc::c_int = 0;
-    let mut idl1: libc::c_int = 0;
-    let mut ix2: libc::c_int = 0;
-    let mut ix3: libc::c_int = 0;
-    nf = *ifac.offset(1 as libc::c_int as isize);
-    na = 1 as libc::c_int;
+    let mut i: c_int = 0;
+    let mut k1: c_int = 0;
+    let mut l1: c_int = 0;
+    let mut l2: c_int = 0;
+    let mut na: c_int = 0;
+    let mut kh: c_int = 0;
+    let mut nf: c_int = 0;
+    let mut ip: c_int = 0;
+    let mut iw: c_int = 0;
+    let mut ido: c_int = 0;
+    let mut idl1: c_int = 0;
+    let mut ix2: c_int = 0;
+    let mut ix3: c_int = 0;
+    nf = *ifac.offset(1 as c_int as isize);
+    na = 1 as c_int;
     l2 = n;
     iw = n;
-    k1 = 0 as libc::c_int;
+    k1 = 0 as c_int;
     while k1 < nf {
         kh = nf - k1;
-        ip = *ifac.offset((kh + 1 as libc::c_int) as isize);
+        ip = *ifac.offset((kh + 1 as c_int) as isize);
         l1 = l2 / ip;
         ido = n / l2;
         idl1 = ido * l1;
-        iw -= (ip - 1 as libc::c_int) * ido;
-        na = 1 as libc::c_int - na;
-        if ip != 4 as libc::c_int {
-            if ip != 2 as libc::c_int {
-                if ido == 1 as libc::c_int {
-                    na = 1 as libc::c_int - na
+        iw -= (ip - 1 as c_int) * ido;
+        na = 1 as c_int - na;
+        if ip != 4 as c_int {
+            if ip != 2 as c_int {
+                if ido == 1 as c_int {
+                    na = 1 as c_int - na
                 }
-                if na != 0 as libc::c_int {
+                if na != 0 as c_int {
                     dradfg(
                         ido,
                         ip,
@@ -914,9 +906,9 @@ unsafe extern "C" fn drftf1(
                         ch,
                         c,
                         c,
-                        wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
+                        wa.offset(iw as isize).offset(-(1 as c_int as isize)),
                     );
-                    na = 0 as libc::c_int
+                    na = 0 as c_int
                 } else {
                     dradfg(
                         ido,
@@ -928,17 +920,17 @@ unsafe extern "C" fn drftf1(
                         c,
                         ch,
                         ch,
-                        wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
+                        wa.offset(iw as isize).offset(-(1 as c_int as isize)),
                     );
-                    na = 1 as libc::c_int
+                    na = 1 as c_int
                 }
-            } else if na != 0 as libc::c_int {
+            } else if na != 0 as c_int {
                 dradf2(
                     ido,
                     l1,
                     ch,
                     c,
-                    wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
+                    wa.offset(iw as isize).offset(-(1 as c_int as isize)),
                 );
             } else {
                 dradf2(
@@ -946,21 +938,21 @@ unsafe extern "C" fn drftf1(
                     l1,
                     c,
                     ch,
-                    wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
+                    wa.offset(iw as isize).offset(-(1 as c_int as isize)),
                 );
             }
         } else {
             ix2 = iw + ido;
             ix3 = ix2 + ido;
-            if na != 0 as libc::c_int {
+            if na != 0 as c_int {
                 dradf4(
                     ido,
                     l1,
                     ch,
                     c,
-                    wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
-                    wa.offset(ix2 as isize).offset(-(1 as libc::c_int as isize)),
-                    wa.offset(ix3 as isize).offset(-(1 as libc::c_int as isize)),
+                    wa.offset(iw as isize).offset(-(1 as c_int as isize)),
+                    wa.offset(ix2 as isize).offset(-(1 as c_int as isize)),
+                    wa.offset(ix3 as isize).offset(-(1 as c_int as isize)),
                 );
             } else {
                 dradf4(
@@ -968,149 +960,147 @@ unsafe extern "C" fn drftf1(
                     l1,
                     c,
                     ch,
-                    wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
-                    wa.offset(ix2 as isize).offset(-(1 as libc::c_int as isize)),
-                    wa.offset(ix3 as isize).offset(-(1 as libc::c_int as isize)),
+                    wa.offset(iw as isize).offset(-(1 as c_int as isize)),
+                    wa.offset(ix2 as isize).offset(-(1 as c_int as isize)),
+                    wa.offset(ix3 as isize).offset(-(1 as c_int as isize)),
                 );
             }
         }
         l2 = l1;
         k1 += 1
     }
-    if na == 1 as libc::c_int {
+    if na == 1 as c_int {
         return;
     }
-    i = 0 as libc::c_int;
+    i = 0 as c_int;
     while i < n {
         *c.offset(i as isize) = *ch.offset(i as isize);
         i += 1
     }
 }
 unsafe extern "C" fn dradb2(
-    mut ido: libc::c_int,
-    mut l1: libc::c_int,
-    mut cc: *mut libc::c_float,
-    mut ch: *mut libc::c_float,
-    mut wa1: *mut libc::c_float,
+    mut ido: c_int,
+    mut l1: c_int,
+    mut cc: *mut c_float,
+    mut ch: *mut c_float,
+    mut wa1: *mut c_float,
 ) {
-    let mut i: libc::c_int = 0;
-    let mut k: libc::c_int = 0;
-    let mut t0: libc::c_int = 0;
-    let mut t1: libc::c_int = 0;
-    let mut t2: libc::c_int = 0;
-    let mut t3: libc::c_int = 0;
-    let mut t4: libc::c_int = 0;
-    let mut t5: libc::c_int = 0;
-    let mut t6: libc::c_int = 0;
-    let mut ti2: libc::c_float = 0.;
-    let mut tr2: libc::c_float = 0.;
+    let mut i: c_int = 0;
+    let mut k: c_int = 0;
+    let mut t0: c_int = 0;
+    let mut t1: c_int = 0;
+    let mut t2: c_int = 0;
+    let mut t3: c_int = 0;
+    let mut t4: c_int = 0;
+    let mut t5: c_int = 0;
+    let mut t6: c_int = 0;
+    let mut ti2: c_float = 0.;
+    let mut tr2: c_float = 0.;
     t0 = l1 * ido;
-    t1 = 0 as libc::c_int;
-    t2 = 0 as libc::c_int;
-    t3 = (ido << 1 as libc::c_int) - 1 as libc::c_int;
-    k = 0 as libc::c_int;
+    t1 = 0 as c_int;
+    t2 = 0 as c_int;
+    t3 = (ido << 1 as c_int) - 1 as c_int;
+    k = 0 as c_int;
     while k < l1 {
         *ch.offset(t1 as isize) = *cc.offset(t2 as isize) + *cc.offset((t3 + t2) as isize);
         *ch.offset((t1 + t0) as isize) = *cc.offset(t2 as isize) - *cc.offset((t3 + t2) as isize);
         t1 += ido;
-        t2 = t1 << 1 as libc::c_int;
+        t2 = t1 << 1 as c_int;
         k += 1
     }
-    if ido < 2 as libc::c_int {
+    if ido < 2 as c_int {
         return;
     }
-    if !(ido == 2 as libc::c_int) {
-        t1 = 0 as libc::c_int;
-        t2 = 0 as libc::c_int;
-        k = 0 as libc::c_int;
+    if !(ido == 2 as c_int) {
+        t1 = 0 as c_int;
+        t2 = 0 as c_int;
+        k = 0 as c_int;
         while k < l1 {
             t3 = t1;
             t4 = t2;
-            t5 = t4 + (ido << 1 as libc::c_int);
+            t5 = t4 + (ido << 1 as c_int);
             t6 = t0 + t1;
-            i = 2 as libc::c_int;
+            i = 2 as c_int;
             while i < ido {
-                t3 += 2 as libc::c_int;
-                t4 += 2 as libc::c_int;
-                t5 -= 2 as libc::c_int;
-                t6 += 2 as libc::c_int;
-                *ch.offset((t3 - 1 as libc::c_int) as isize) = *cc
-                    .offset((t4 - 1 as libc::c_int) as isize)
-                    + *cc.offset((t5 - 1 as libc::c_int) as isize);
-                tr2 = *cc.offset((t4 - 1 as libc::c_int) as isize)
-                    - *cc.offset((t5 - 1 as libc::c_int) as isize);
+                t3 += 2 as c_int;
+                t4 += 2 as c_int;
+                t5 -= 2 as c_int;
+                t6 += 2 as c_int;
+                *ch.offset((t3 - 1 as c_int) as isize) =
+                    *cc.offset((t4 - 1 as c_int) as isize) + *cc.offset((t5 - 1 as c_int) as isize);
+                tr2 =
+                    *cc.offset((t4 - 1 as c_int) as isize) - *cc.offset((t5 - 1 as c_int) as isize);
                 *ch.offset(t3 as isize) = *cc.offset(t4 as isize) - *cc.offset(t5 as isize);
                 ti2 = *cc.offset(t4 as isize) + *cc.offset(t5 as isize);
-                *ch.offset((t6 - 1 as libc::c_int) as isize) =
-                    *wa1.offset((i - 2 as libc::c_int) as isize) * tr2
-                        - *wa1.offset((i - 1 as libc::c_int) as isize) * ti2;
-                *ch.offset(t6 as isize) = *wa1.offset((i - 2 as libc::c_int) as isize) * ti2
-                    + *wa1.offset((i - 1 as libc::c_int) as isize) * tr2;
-                i += 2 as libc::c_int
+                *ch.offset((t6 - 1 as c_int) as isize) = *wa1.offset((i - 2 as c_int) as isize)
+                    * tr2
+                    - *wa1.offset((i - 1 as c_int) as isize) * ti2;
+                *ch.offset(t6 as isize) = *wa1.offset((i - 2 as c_int) as isize) * ti2
+                    + *wa1.offset((i - 1 as c_int) as isize) * tr2;
+                i += 2 as c_int
             }
             t1 += ido;
-            t2 = t1 << 1 as libc::c_int;
+            t2 = t1 << 1 as c_int;
             k += 1
         }
-        if ido % 2 as libc::c_int == 1 as libc::c_int {
+        if ido % 2 as c_int == 1 as c_int {
             return;
         }
     }
-    t1 = ido - 1 as libc::c_int;
-    t2 = ido - 1 as libc::c_int;
-    k = 0 as libc::c_int;
+    t1 = ido - 1 as c_int;
+    t2 = ido - 1 as c_int;
+    k = 0 as c_int;
     while k < l1 {
         *ch.offset(t1 as isize) = *cc.offset(t2 as isize) + *cc.offset(t2 as isize);
-        *ch.offset((t1 + t0) as isize) = -(*cc.offset((t2 + 1 as libc::c_int) as isize)
-            + *cc.offset((t2 + 1 as libc::c_int) as isize));
+        *ch.offset((t1 + t0) as isize) =
+            -(*cc.offset((t2 + 1 as c_int) as isize) + *cc.offset((t2 + 1 as c_int) as isize));
         t1 += ido;
-        t2 += ido << 1 as libc::c_int;
+        t2 += ido << 1 as c_int;
         k += 1
     }
 }
 unsafe extern "C" fn dradb3(
-    mut ido: libc::c_int,
-    mut l1: libc::c_int,
-    mut cc: *mut libc::c_float,
-    mut ch: *mut libc::c_float,
-    mut wa1: *mut libc::c_float,
-    mut wa2: *mut libc::c_float,
+    mut ido: c_int,
+    mut l1: c_int,
+    mut cc: *mut c_float,
+    mut ch: *mut c_float,
+    mut wa1: *mut c_float,
+    mut wa2: *mut c_float,
 ) {
-    static mut taur: libc::c_float = -0.5f32;
-    static mut taui: libc::c_float = 0.8660254037844386f32;
-    let mut i: libc::c_int = 0;
-    let mut k: libc::c_int = 0;
-    let mut t0: libc::c_int = 0;
-    let mut t1: libc::c_int = 0;
-    let mut t2: libc::c_int = 0;
-    let mut t3: libc::c_int = 0;
-    let mut t4: libc::c_int = 0;
-    let mut t5: libc::c_int = 0;
-    let mut t6: libc::c_int = 0;
-    let mut t7: libc::c_int = 0;
-    let mut t8: libc::c_int = 0;
-    let mut t9: libc::c_int = 0;
-    let mut t10: libc::c_int = 0;
-    let mut ci2: libc::c_float = 0.;
-    let mut ci3: libc::c_float = 0.;
-    let mut di2: libc::c_float = 0.;
-    let mut di3: libc::c_float = 0.;
-    let mut cr2: libc::c_float = 0.;
-    let mut cr3: libc::c_float = 0.;
-    let mut dr2: libc::c_float = 0.;
-    let mut dr3: libc::c_float = 0.;
-    let mut ti2: libc::c_float = 0.;
-    let mut tr2: libc::c_float = 0.;
+    static mut taur: c_float = -0.5f32;
+    static mut taui: c_float = 0.8660254037844386f32;
+    let mut i: c_int = 0;
+    let mut k: c_int = 0;
+    let mut t0: c_int = 0;
+    let mut t1: c_int = 0;
+    let mut t2: c_int = 0;
+    let mut t3: c_int = 0;
+    let mut t4: c_int = 0;
+    let mut t5: c_int = 0;
+    let mut t6: c_int = 0;
+    let mut t7: c_int = 0;
+    let mut t8: c_int = 0;
+    let mut t9: c_int = 0;
+    let mut t10: c_int = 0;
+    let mut ci2: c_float = 0.;
+    let mut ci3: c_float = 0.;
+    let mut di2: c_float = 0.;
+    let mut di3: c_float = 0.;
+    let mut cr2: c_float = 0.;
+    let mut cr3: c_float = 0.;
+    let mut dr2: c_float = 0.;
+    let mut dr3: c_float = 0.;
+    let mut ti2: c_float = 0.;
+    let mut tr2: c_float = 0.;
     t0 = l1 * ido;
-    t1 = 0 as libc::c_int;
-    t2 = t0 << 1 as libc::c_int;
-    t3 = ido << 1 as libc::c_int;
-    t4 = ido + (ido << 1 as libc::c_int);
-    t5 = 0 as libc::c_int;
-    k = 0 as libc::c_int;
+    t1 = 0 as c_int;
+    t2 = t0 << 1 as c_int;
+    t3 = ido << 1 as c_int;
+    t4 = ido + (ido << 1 as c_int);
+    t5 = 0 as c_int;
+    k = 0 as c_int;
     while k < l1 {
-        tr2 = *cc.offset((t3 - 1 as libc::c_int) as isize)
-            + *cc.offset((t3 - 1 as libc::c_int) as isize);
+        tr2 = *cc.offset((t3 - 1 as c_int) as isize) + *cc.offset((t3 - 1 as c_int) as isize);
         cr2 = *cc.offset(t5 as isize) + taur * tr2;
         *ch.offset(t1 as isize) = *cc.offset(t5 as isize) + tr2;
         ci3 = taui * (*cc.offset(t3 as isize) + *cc.offset(t3 as isize));
@@ -1121,109 +1111,103 @@ unsafe extern "C" fn dradb3(
         t5 += t4;
         k += 1
     }
-    if ido == 1 as libc::c_int {
+    if ido == 1 as c_int {
         return;
     }
-    t1 = 0 as libc::c_int;
-    t3 = ido << 1 as libc::c_int;
-    k = 0 as libc::c_int;
+    t1 = 0 as c_int;
+    t3 = ido << 1 as c_int;
+    k = 0 as c_int;
     while k < l1 {
-        t7 = t1 + (t1 << 1 as libc::c_int);
+        t7 = t1 + (t1 << 1 as c_int);
         t5 = t7 + t3;
         t6 = t5;
         t8 = t1;
         t9 = t1 + t0;
         t10 = t9 + t0;
-        i = 2 as libc::c_int;
+        i = 2 as c_int;
         while i < ido {
-            t5 += 2 as libc::c_int;
-            t6 -= 2 as libc::c_int;
-            t7 += 2 as libc::c_int;
-            t8 += 2 as libc::c_int;
-            t9 += 2 as libc::c_int;
-            t10 += 2 as libc::c_int;
-            tr2 = *cc.offset((t5 - 1 as libc::c_int) as isize)
-                + *cc.offset((t6 - 1 as libc::c_int) as isize);
-            cr2 = *cc.offset((t7 - 1 as libc::c_int) as isize) + taur * tr2;
-            *ch.offset((t8 - 1 as libc::c_int) as isize) =
-                *cc.offset((t7 - 1 as libc::c_int) as isize) + tr2;
+            t5 += 2 as c_int;
+            t6 -= 2 as c_int;
+            t7 += 2 as c_int;
+            t8 += 2 as c_int;
+            t9 += 2 as c_int;
+            t10 += 2 as c_int;
+            tr2 = *cc.offset((t5 - 1 as c_int) as isize) + *cc.offset((t6 - 1 as c_int) as isize);
+            cr2 = *cc.offset((t7 - 1 as c_int) as isize) + taur * tr2;
+            *ch.offset((t8 - 1 as c_int) as isize) = *cc.offset((t7 - 1 as c_int) as isize) + tr2;
             ti2 = *cc.offset(t5 as isize) - *cc.offset(t6 as isize);
             ci2 = *cc.offset(t7 as isize) + taur * ti2;
             *ch.offset(t8 as isize) = *cc.offset(t7 as isize) + ti2;
             cr3 = taui
-                * (*cc.offset((t5 - 1 as libc::c_int) as isize)
-                    - *cc.offset((t6 - 1 as libc::c_int) as isize));
+                * (*cc.offset((t5 - 1 as c_int) as isize) - *cc.offset((t6 - 1 as c_int) as isize));
             ci3 = taui * (*cc.offset(t5 as isize) + *cc.offset(t6 as isize));
             dr2 = cr2 - ci3;
             dr3 = cr2 + ci3;
             di2 = ci2 + cr3;
             di3 = ci2 - cr3;
-            *ch.offset((t9 - 1 as libc::c_int) as isize) =
-                *wa1.offset((i - 2 as libc::c_int) as isize) * dr2
-                    - *wa1.offset((i - 1 as libc::c_int) as isize) * di2;
-            *ch.offset(t9 as isize) = *wa1.offset((i - 2 as libc::c_int) as isize) * di2
-                + *wa1.offset((i - 1 as libc::c_int) as isize) * dr2;
-            *ch.offset((t10 - 1 as libc::c_int) as isize) =
-                *wa2.offset((i - 2 as libc::c_int) as isize) * dr3
-                    - *wa2.offset((i - 1 as libc::c_int) as isize) * di3;
-            *ch.offset(t10 as isize) = *wa2.offset((i - 2 as libc::c_int) as isize) * di3
-                + *wa2.offset((i - 1 as libc::c_int) as isize) * dr3;
-            i += 2 as libc::c_int
+            *ch.offset((t9 - 1 as c_int) as isize) = *wa1.offset((i - 2 as c_int) as isize) * dr2
+                - *wa1.offset((i - 1 as c_int) as isize) * di2;
+            *ch.offset(t9 as isize) = *wa1.offset((i - 2 as c_int) as isize) * di2
+                + *wa1.offset((i - 1 as c_int) as isize) * dr2;
+            *ch.offset((t10 - 1 as c_int) as isize) = *wa2.offset((i - 2 as c_int) as isize) * dr3
+                - *wa2.offset((i - 1 as c_int) as isize) * di3;
+            *ch.offset(t10 as isize) = *wa2.offset((i - 2 as c_int) as isize) * di3
+                + *wa2.offset((i - 1 as c_int) as isize) * dr3;
+            i += 2 as c_int
         }
         t1 += ido;
         k += 1
     }
 }
 unsafe extern "C" fn dradb4(
-    mut ido: libc::c_int,
-    mut l1: libc::c_int,
-    mut cc: *mut libc::c_float,
-    mut ch: *mut libc::c_float,
-    mut wa1: *mut libc::c_float,
-    mut wa2: *mut libc::c_float,
-    mut wa3: *mut libc::c_float,
+    mut ido: c_int,
+    mut l1: c_int,
+    mut cc: *mut c_float,
+    mut ch: *mut c_float,
+    mut wa1: *mut c_float,
+    mut wa2: *mut c_float,
+    mut wa3: *mut c_float,
 ) {
-    static mut sqrt2: libc::c_float = 1.414213562373095f32;
-    let mut i: libc::c_int = 0;
-    let mut k: libc::c_int = 0;
-    let mut t0: libc::c_int = 0;
-    let mut t1: libc::c_int = 0;
-    let mut t2: libc::c_int = 0;
-    let mut t3: libc::c_int = 0;
-    let mut t4: libc::c_int = 0;
-    let mut t5: libc::c_int = 0;
-    let mut t6: libc::c_int = 0;
-    let mut t7: libc::c_int = 0;
-    let mut t8: libc::c_int = 0;
-    let mut ci2: libc::c_float = 0.;
-    let mut ci3: libc::c_float = 0.;
-    let mut ci4: libc::c_float = 0.;
-    let mut cr2: libc::c_float = 0.;
-    let mut cr3: libc::c_float = 0.;
-    let mut cr4: libc::c_float = 0.;
-    let mut ti1: libc::c_float = 0.;
-    let mut ti2: libc::c_float = 0.;
-    let mut ti3: libc::c_float = 0.;
-    let mut ti4: libc::c_float = 0.;
-    let mut tr1: libc::c_float = 0.;
-    let mut tr2: libc::c_float = 0.;
-    let mut tr3: libc::c_float = 0.;
-    let mut tr4: libc::c_float = 0.;
+    static mut sqrt2: c_float = 1.414213562373095f32;
+    let mut i: c_int = 0;
+    let mut k: c_int = 0;
+    let mut t0: c_int = 0;
+    let mut t1: c_int = 0;
+    let mut t2: c_int = 0;
+    let mut t3: c_int = 0;
+    let mut t4: c_int = 0;
+    let mut t5: c_int = 0;
+    let mut t6: c_int = 0;
+    let mut t7: c_int = 0;
+    let mut t8: c_int = 0;
+    let mut ci2: c_float = 0.;
+    let mut ci3: c_float = 0.;
+    let mut ci4: c_float = 0.;
+    let mut cr2: c_float = 0.;
+    let mut cr3: c_float = 0.;
+    let mut cr4: c_float = 0.;
+    let mut ti1: c_float = 0.;
+    let mut ti2: c_float = 0.;
+    let mut ti3: c_float = 0.;
+    let mut ti4: c_float = 0.;
+    let mut tr1: c_float = 0.;
+    let mut tr2: c_float = 0.;
+    let mut tr3: c_float = 0.;
+    let mut tr4: c_float = 0.;
     t0 = l1 * ido;
-    t1 = 0 as libc::c_int;
-    t2 = ido << 2 as libc::c_int;
-    t3 = 0 as libc::c_int;
-    t6 = ido << 1 as libc::c_int;
-    k = 0 as libc::c_int;
+    t1 = 0 as c_int;
+    t2 = ido << 2 as c_int;
+    t3 = 0 as c_int;
+    t6 = ido << 1 as c_int;
+    k = 0 as c_int;
     while k < l1 {
         t4 = t3 + t6;
         t5 = t1;
-        tr3 = *cc.offset((t4 - 1 as libc::c_int) as isize)
-            + *cc.offset((t4 - 1 as libc::c_int) as isize);
+        tr3 = *cc.offset((t4 - 1 as c_int) as isize) + *cc.offset((t4 - 1 as c_int) as isize);
         tr4 = *cc.offset(t4 as isize) + *cc.offset(t4 as isize);
         t4 += t6;
-        tr1 = *cc.offset(t3 as isize) - *cc.offset((t4 - 1 as libc::c_int) as isize);
-        tr2 = *cc.offset(t3 as isize) + *cc.offset((t4 - 1 as libc::c_int) as isize);
+        tr1 = *cc.offset(t3 as isize) - *cc.offset((t4 - 1 as c_int) as isize);
+        tr2 = *cc.offset(t3 as isize) + *cc.offset((t4 - 1 as c_int) as isize);
         *ch.offset(t5 as isize) = tr2 + tr3;
         t5 += t0;
         *ch.offset(t5 as isize) = tr1 - tr4;
@@ -1235,38 +1219,38 @@ unsafe extern "C" fn dradb4(
         t3 += t2;
         k += 1
     }
-    if ido < 2 as libc::c_int {
+    if ido < 2 as c_int {
         return;
     }
-    if !(ido == 2 as libc::c_int) {
-        t1 = 0 as libc::c_int;
-        k = 0 as libc::c_int;
+    if !(ido == 2 as c_int) {
+        t1 = 0 as c_int;
+        k = 0 as c_int;
         while k < l1 {
-            t2 = t1 << 2 as libc::c_int;
+            t2 = t1 << 2 as c_int;
             t3 = t2 + t6;
             t4 = t3;
             t5 = t4 + t6;
             t7 = t1;
-            i = 2 as libc::c_int;
+            i = 2 as c_int;
             while i < ido {
-                t2 += 2 as libc::c_int;
-                t3 += 2 as libc::c_int;
-                t4 -= 2 as libc::c_int;
-                t5 -= 2 as libc::c_int;
-                t7 += 2 as libc::c_int;
+                t2 += 2 as c_int;
+                t3 += 2 as c_int;
+                t4 -= 2 as c_int;
+                t5 -= 2 as c_int;
+                t7 += 2 as c_int;
                 ti1 = *cc.offset(t2 as isize) + *cc.offset(t5 as isize);
                 ti2 = *cc.offset(t2 as isize) - *cc.offset(t5 as isize);
                 ti3 = *cc.offset(t3 as isize) - *cc.offset(t4 as isize);
                 tr4 = *cc.offset(t3 as isize) + *cc.offset(t4 as isize);
-                tr1 = *cc.offset((t2 - 1 as libc::c_int) as isize)
-                    - *cc.offset((t5 - 1 as libc::c_int) as isize);
-                tr2 = *cc.offset((t2 - 1 as libc::c_int) as isize)
-                    + *cc.offset((t5 - 1 as libc::c_int) as isize);
-                ti4 = *cc.offset((t3 - 1 as libc::c_int) as isize)
-                    - *cc.offset((t4 - 1 as libc::c_int) as isize);
-                tr3 = *cc.offset((t3 - 1 as libc::c_int) as isize)
-                    + *cc.offset((t4 - 1 as libc::c_int) as isize);
-                *ch.offset((t7 - 1 as libc::c_int) as isize) = tr2 + tr3;
+                tr1 =
+                    *cc.offset((t2 - 1 as c_int) as isize) - *cc.offset((t5 - 1 as c_int) as isize);
+                tr2 =
+                    *cc.offset((t2 - 1 as c_int) as isize) + *cc.offset((t5 - 1 as c_int) as isize);
+                ti4 =
+                    *cc.offset((t3 - 1 as c_int) as isize) - *cc.offset((t4 - 1 as c_int) as isize);
+                tr3 =
+                    *cc.offset((t3 - 1 as c_int) as isize) + *cc.offset((t4 - 1 as c_int) as isize);
+                *ch.offset((t7 - 1 as c_int) as isize) = tr2 + tr3;
                 cr3 = tr2 - tr3;
                 *ch.offset(t7 as isize) = ti2 + ti3;
                 ci3 = ti2 - ti3;
@@ -1275,45 +1259,43 @@ unsafe extern "C" fn dradb4(
                 ci2 = ti1 + ti4;
                 ci4 = ti1 - ti4;
                 t8 = t7 + t0;
-                *ch.offset((t8 - 1 as libc::c_int) as isize) =
-                    *wa1.offset((i - 2 as libc::c_int) as isize) * cr2
-                        - *wa1.offset((i - 1 as libc::c_int) as isize) * ci2;
-                *ch.offset(t8 as isize) = *wa1.offset((i - 2 as libc::c_int) as isize) * ci2
-                    + *wa1.offset((i - 1 as libc::c_int) as isize) * cr2;
+                *ch.offset((t8 - 1 as c_int) as isize) = *wa1.offset((i - 2 as c_int) as isize)
+                    * cr2
+                    - *wa1.offset((i - 1 as c_int) as isize) * ci2;
+                *ch.offset(t8 as isize) = *wa1.offset((i - 2 as c_int) as isize) * ci2
+                    + *wa1.offset((i - 1 as c_int) as isize) * cr2;
                 t8 += t0;
-                *ch.offset((t8 - 1 as libc::c_int) as isize) =
-                    *wa2.offset((i - 2 as libc::c_int) as isize) * cr3
-                        - *wa2.offset((i - 1 as libc::c_int) as isize) * ci3;
-                *ch.offset(t8 as isize) = *wa2.offset((i - 2 as libc::c_int) as isize) * ci3
-                    + *wa2.offset((i - 1 as libc::c_int) as isize) * cr3;
+                *ch.offset((t8 - 1 as c_int) as isize) = *wa2.offset((i - 2 as c_int) as isize)
+                    * cr3
+                    - *wa2.offset((i - 1 as c_int) as isize) * ci3;
+                *ch.offset(t8 as isize) = *wa2.offset((i - 2 as c_int) as isize) * ci3
+                    + *wa2.offset((i - 1 as c_int) as isize) * cr3;
                 t8 += t0;
-                *ch.offset((t8 - 1 as libc::c_int) as isize) =
-                    *wa3.offset((i - 2 as libc::c_int) as isize) * cr4
-                        - *wa3.offset((i - 1 as libc::c_int) as isize) * ci4;
-                *ch.offset(t8 as isize) = *wa3.offset((i - 2 as libc::c_int) as isize) * ci4
-                    + *wa3.offset((i - 1 as libc::c_int) as isize) * cr4;
-                i += 2 as libc::c_int
+                *ch.offset((t8 - 1 as c_int) as isize) = *wa3.offset((i - 2 as c_int) as isize)
+                    * cr4
+                    - *wa3.offset((i - 1 as c_int) as isize) * ci4;
+                *ch.offset(t8 as isize) = *wa3.offset((i - 2 as c_int) as isize) * ci4
+                    + *wa3.offset((i - 1 as c_int) as isize) * cr4;
+                i += 2 as c_int
             }
             t1 += ido;
             k += 1
         }
-        if ido % 2 as libc::c_int == 1 as libc::c_int {
+        if ido % 2 as c_int == 1 as c_int {
             return;
         }
     }
     t1 = ido;
-    t2 = ido << 2 as libc::c_int;
-    t3 = ido - 1 as libc::c_int;
-    t4 = ido + (ido << 1 as libc::c_int);
-    k = 0 as libc::c_int;
+    t2 = ido << 2 as c_int;
+    t3 = ido - 1 as c_int;
+    t4 = ido + (ido << 1 as c_int);
+    k = 0 as c_int;
     while k < l1 {
         t5 = t3;
         ti1 = *cc.offset(t1 as isize) + *cc.offset(t4 as isize);
         ti2 = *cc.offset(t4 as isize) - *cc.offset(t1 as isize);
-        tr1 = *cc.offset((t1 - 1 as libc::c_int) as isize)
-            - *cc.offset((t4 - 1 as libc::c_int) as isize);
-        tr2 = *cc.offset((t1 - 1 as libc::c_int) as isize)
-            + *cc.offset((t4 - 1 as libc::c_int) as isize);
+        tr1 = *cc.offset((t1 - 1 as c_int) as isize) - *cc.offset((t4 - 1 as c_int) as isize);
+        tr2 = *cc.offset((t1 - 1 as c_int) as isize) + *cc.offset((t4 - 1 as c_int) as isize);
         *ch.offset(t5 as isize) = tr2 + tr2;
         t5 += t0;
         *ch.offset(t5 as isize) = sqrt2 * (tr1 - ti1);
@@ -1328,67 +1310,67 @@ unsafe extern "C" fn dradb4(
     }
 }
 unsafe extern "C" fn dradbg(
-    mut ido: libc::c_int,
-    mut ip: libc::c_int,
-    mut l1: libc::c_int,
-    mut idl1: libc::c_int,
-    mut cc: *mut libc::c_float,
-    mut c1: *mut libc::c_float,
-    mut c2: *mut libc::c_float,
-    mut ch: *mut libc::c_float,
-    mut ch2: *mut libc::c_float,
-    mut wa: *mut libc::c_float,
+    mut ido: c_int,
+    mut ip: c_int,
+    mut l1: c_int,
+    mut idl1: c_int,
+    mut cc: *mut c_float,
+    mut c1: *mut c_float,
+    mut c2: *mut c_float,
+    mut ch: *mut c_float,
+    mut ch2: *mut c_float,
+    mut wa: *mut c_float,
 ) {
-    static mut tpi: libc::c_float = 6.283185307179586f32;
-    let mut idij: libc::c_int = 0;
-    let mut ipph: libc::c_int = 0;
-    let mut i: libc::c_int = 0;
-    let mut j: libc::c_int = 0;
-    let mut k: libc::c_int = 0;
-    let mut l: libc::c_int = 0;
-    let mut ik: libc::c_int = 0;
-    let mut is: libc::c_int = 0;
-    let mut t0: libc::c_int = 0;
-    let mut t1: libc::c_int = 0;
-    let mut t2: libc::c_int = 0;
-    let mut t3: libc::c_int = 0;
-    let mut t4: libc::c_int = 0;
-    let mut t5: libc::c_int = 0;
-    let mut t6: libc::c_int = 0;
-    let mut t7: libc::c_int = 0;
-    let mut t8: libc::c_int = 0;
-    let mut t9: libc::c_int = 0;
-    let mut t10: libc::c_int = 0;
-    let mut t11: libc::c_int = 0;
-    let mut t12: libc::c_int = 0;
-    let mut dc2: libc::c_float = 0.;
-    let mut ai1: libc::c_float = 0.;
-    let mut ai2: libc::c_float = 0.;
-    let mut ar1: libc::c_float = 0.;
-    let mut ar2: libc::c_float = 0.;
-    let mut ds2: libc::c_float = 0.;
-    let mut nbd: libc::c_int = 0;
-    let mut dcp: libc::c_float = 0.;
-    let mut arg: libc::c_float = 0.;
-    let mut dsp: libc::c_float = 0.;
-    let mut ar1h: libc::c_float = 0.;
-    let mut ar2h: libc::c_float = 0.;
-    let mut ipp2: libc::c_int = 0;
+    static mut tpi: c_float = 6.283185307179586f32;
+    let mut idij: c_int = 0;
+    let mut ipph: c_int = 0;
+    let mut i: c_int = 0;
+    let mut j: c_int = 0;
+    let mut k: c_int = 0;
+    let mut l: c_int = 0;
+    let mut ik: c_int = 0;
+    let mut is: c_int = 0;
+    let mut t0: c_int = 0;
+    let mut t1: c_int = 0;
+    let mut t2: c_int = 0;
+    let mut t3: c_int = 0;
+    let mut t4: c_int = 0;
+    let mut t5: c_int = 0;
+    let mut t6: c_int = 0;
+    let mut t7: c_int = 0;
+    let mut t8: c_int = 0;
+    let mut t9: c_int = 0;
+    let mut t10: c_int = 0;
+    let mut t11: c_int = 0;
+    let mut t12: c_int = 0;
+    let mut dc2: c_float = 0.;
+    let mut ai1: c_float = 0.;
+    let mut ai2: c_float = 0.;
+    let mut ar1: c_float = 0.;
+    let mut ar2: c_float = 0.;
+    let mut ds2: c_float = 0.;
+    let mut nbd: c_int = 0;
+    let mut dcp: c_float = 0.;
+    let mut arg: c_float = 0.;
+    let mut dsp: c_float = 0.;
+    let mut ar1h: c_float = 0.;
+    let mut ar2h: c_float = 0.;
+    let mut ipp2: c_int = 0;
     t10 = ip * ido;
     t0 = l1 * ido;
-    arg = tpi / ip as libc::c_float;
-    dcp = cos(arg as libc::c_double) as libc::c_float;
-    dsp = sin(arg as libc::c_double) as libc::c_float;
-    nbd = ido - 1 as libc::c_int >> 1 as libc::c_int;
+    arg = tpi / ip as c_float;
+    dcp = cos(arg as c_double) as c_float;
+    dsp = sin(arg as c_double) as c_float;
+    nbd = ido - 1 as c_int >> 1 as c_int;
     ipp2 = ip;
-    ipph = ip + 1 as libc::c_int >> 1 as libc::c_int;
+    ipph = ip + 1 as c_int >> 1 as c_int;
     if ido < l1 {
-        t1 = 0 as libc::c_int;
-        i = 0 as libc::c_int;
+        t1 = 0 as c_int;
+        i = 0 as c_int;
         while i < ido {
             t2 = t1;
             t3 = t1;
-            k = 0 as libc::c_int;
+            k = 0 as c_int;
             while k < l1 {
                 *ch.offset(t2 as isize) = *cc.offset(t3 as isize);
                 t2 += ido;
@@ -1399,13 +1381,13 @@ unsafe extern "C" fn dradbg(
             i += 1
         }
     } else {
-        t1 = 0 as libc::c_int;
-        t2 = 0 as libc::c_int;
-        k = 0 as libc::c_int;
+        t1 = 0 as c_int;
+        t2 = 0 as c_int;
+        k = 0 as c_int;
         while k < l1 {
             t3 = t1;
             t4 = t2;
-            i = 0 as libc::c_int;
+            i = 0 as c_int;
             while i < ido {
                 *ch.offset(t3 as isize) = *cc.offset(t4 as isize);
                 t3 += 1;
@@ -1417,21 +1399,21 @@ unsafe extern "C" fn dradbg(
             k += 1
         }
     }
-    t1 = 0 as libc::c_int;
+    t1 = 0 as c_int;
     t2 = ipp2 * t0;
-    t5 = ido << 1 as libc::c_int;
+    t5 = ido << 1 as c_int;
     t7 = t5;
-    j = 1 as libc::c_int;
+    j = 1 as c_int;
     while j < ipph {
         t1 += t0;
         t2 -= t0;
         t3 = t1;
         t4 = t2;
         t6 = t5;
-        k = 0 as libc::c_int;
+        k = 0 as c_int;
         while k < l1 {
-            *ch.offset(t3 as isize) = *cc.offset((t6 - 1 as libc::c_int) as isize)
-                + *cc.offset((t6 - 1 as libc::c_int) as isize);
+            *ch.offset(t3 as isize) =
+                *cc.offset((t6 - 1 as c_int) as isize) + *cc.offset((t6 - 1 as c_int) as isize);
             *ch.offset(t4 as isize) = *cc.offset(t6 as isize) + *cc.offset(t6 as isize);
             t3 += ido;
             t4 += ido;
@@ -1441,38 +1423,38 @@ unsafe extern "C" fn dradbg(
         t5 += t7;
         j += 1
     }
-    if !(ido == 1 as libc::c_int) {
+    if !(ido == 1 as c_int) {
         if nbd < l1 {
-            t1 = 0 as libc::c_int;
+            t1 = 0 as c_int;
             t2 = ipp2 * t0;
-            t7 = 0 as libc::c_int;
-            j = 1 as libc::c_int;
+            t7 = 0 as c_int;
+            j = 1 as c_int;
             while j < ipph {
                 t1 += t0;
                 t2 -= t0;
                 t3 = t1;
                 t4 = t2;
-                t7 += ido << 1 as libc::c_int;
+                t7 += ido << 1 as c_int;
                 t8 = t7;
                 t9 = t7;
-                i = 2 as libc::c_int;
+                i = 2 as c_int;
                 while i < ido {
-                    t3 += 2 as libc::c_int;
-                    t4 += 2 as libc::c_int;
-                    t8 += 2 as libc::c_int;
-                    t9 -= 2 as libc::c_int;
+                    t3 += 2 as c_int;
+                    t4 += 2 as c_int;
+                    t8 += 2 as c_int;
+                    t9 -= 2 as c_int;
                     t5 = t3;
                     t6 = t4;
                     t11 = t8;
                     t12 = t9;
-                    k = 0 as libc::c_int;
+                    k = 0 as c_int;
                     while k < l1 {
-                        *ch.offset((t5 - 1 as libc::c_int) as isize) = *cc
-                            .offset((t11 - 1 as libc::c_int) as isize)
-                            + *cc.offset((t12 - 1 as libc::c_int) as isize);
-                        *ch.offset((t6 - 1 as libc::c_int) as isize) = *cc
-                            .offset((t11 - 1 as libc::c_int) as isize)
-                            - *cc.offset((t12 - 1 as libc::c_int) as isize);
+                        *ch.offset((t5 - 1 as c_int) as isize) = *cc
+                            .offset((t11 - 1 as c_int) as isize)
+                            + *cc.offset((t12 - 1 as c_int) as isize);
+                        *ch.offset((t6 - 1 as c_int) as isize) = *cc
+                            .offset((t11 - 1 as c_int) as isize)
+                            - *cc.offset((t12 - 1 as c_int) as isize);
                         *ch.offset(t5 as isize) =
                             *cc.offset(t11 as isize) - *cc.offset(t12 as isize);
                         *ch.offset(t6 as isize) =
@@ -1483,45 +1465,45 @@ unsafe extern "C" fn dradbg(
                         t12 += t10;
                         k += 1
                     }
-                    i += 2 as libc::c_int
+                    i += 2 as c_int
                 }
                 j += 1
             }
         } else {
-            t1 = 0 as libc::c_int;
+            t1 = 0 as c_int;
             t2 = ipp2 * t0;
-            t7 = 0 as libc::c_int;
-            j = 1 as libc::c_int;
+            t7 = 0 as c_int;
+            j = 1 as c_int;
             while j < ipph {
                 t1 += t0;
                 t2 -= t0;
                 t3 = t1;
                 t4 = t2;
-                t7 += ido << 1 as libc::c_int;
+                t7 += ido << 1 as c_int;
                 t8 = t7;
-                k = 0 as libc::c_int;
+                k = 0 as c_int;
                 while k < l1 {
                     t5 = t3;
                     t6 = t4;
                     t9 = t8;
                     t11 = t8;
-                    i = 2 as libc::c_int;
+                    i = 2 as c_int;
                     while i < ido {
-                        t5 += 2 as libc::c_int;
-                        t6 += 2 as libc::c_int;
-                        t9 += 2 as libc::c_int;
-                        t11 -= 2 as libc::c_int;
-                        *ch.offset((t5 - 1 as libc::c_int) as isize) = *cc
-                            .offset((t9 - 1 as libc::c_int) as isize)
-                            + *cc.offset((t11 - 1 as libc::c_int) as isize);
-                        *ch.offset((t6 - 1 as libc::c_int) as isize) = *cc
-                            .offset((t9 - 1 as libc::c_int) as isize)
-                            - *cc.offset((t11 - 1 as libc::c_int) as isize);
+                        t5 += 2 as c_int;
+                        t6 += 2 as c_int;
+                        t9 += 2 as c_int;
+                        t11 -= 2 as c_int;
+                        *ch.offset((t5 - 1 as c_int) as isize) = *cc
+                            .offset((t9 - 1 as c_int) as isize)
+                            + *cc.offset((t11 - 1 as c_int) as isize);
+                        *ch.offset((t6 - 1 as c_int) as isize) = *cc
+                            .offset((t9 - 1 as c_int) as isize)
+                            - *cc.offset((t11 - 1 as c_int) as isize);
                         *ch.offset(t5 as isize) =
                             *cc.offset(t9 as isize) - *cc.offset(t11 as isize);
                         *ch.offset(t6 as isize) =
                             *cc.offset(t9 as isize) + *cc.offset(t11 as isize);
-                        i += 2 as libc::c_int
+                        i += 2 as c_int
                     }
                     t3 += ido;
                     t4 += ido;
@@ -1534,11 +1516,11 @@ unsafe extern "C" fn dradbg(
     }
     ar1 = 1.0f32;
     ai1 = 0.0f32;
-    t1 = 0 as libc::c_int;
+    t1 = 0 as c_int;
     t2 = ipp2 * idl1;
     t9 = t2;
-    t3 = (ip - 1 as libc::c_int) * idl1;
-    l = 1 as libc::c_int;
+    t3 = (ip - 1 as c_int) * idl1;
+    l = 1 as c_int;
     while l < ipph {
         t1 += idl1;
         t2 -= idl1;
@@ -1547,10 +1529,10 @@ unsafe extern "C" fn dradbg(
         ar1 = ar1h;
         t4 = t1;
         t5 = t2;
-        t6 = 0 as libc::c_int;
+        t6 = 0 as c_int;
         t7 = idl1;
         t8 = t3;
-        ik = 0 as libc::c_int;
+        ik = 0 as c_int;
         while ik < idl1 {
             let fresh13 = t6;
             t6 = t6 + 1;
@@ -1573,7 +1555,7 @@ unsafe extern "C" fn dradbg(
         ai2 = ai1;
         t6 = idl1;
         t7 = t9 - idl1;
-        j = 2 as libc::c_int;
+        j = 2 as c_int;
         while j < ipph {
             t6 += idl1;
             t7 -= idl1;
@@ -1584,7 +1566,7 @@ unsafe extern "C" fn dradbg(
             t5 = t2;
             t11 = t6;
             t12 = t7;
-            ik = 0 as libc::c_int;
+            ik = 0 as c_int;
             while ik < idl1 {
                 let fresh18 = t11;
                 t11 = t11 + 1;
@@ -1602,12 +1584,12 @@ unsafe extern "C" fn dradbg(
         }
         l += 1
     }
-    t1 = 0 as libc::c_int;
-    j = 1 as libc::c_int;
+    t1 = 0 as c_int;
+    j = 1 as c_int;
     while j < ipph {
         t1 += idl1;
         t2 = t1;
-        ik = 0 as libc::c_int;
+        ik = 0 as c_int;
         while ik < idl1 {
             let fresh22 = t2;
             t2 = t2 + 1;
@@ -1616,15 +1598,15 @@ unsafe extern "C" fn dradbg(
         }
         j += 1
     }
-    t1 = 0 as libc::c_int;
+    t1 = 0 as c_int;
     t2 = ipp2 * t0;
-    j = 1 as libc::c_int;
+    j = 1 as c_int;
     while j < ipph {
         t1 += t0;
         t2 -= t0;
         t3 = t1;
         t4 = t2;
-        k = 0 as libc::c_int;
+        k = 0 as c_int;
         while k < l1 {
             *ch.offset(t3 as isize) = *c1.offset(t3 as isize) - *c1.offset(t4 as isize);
             *ch.offset(t4 as isize) = *c1.offset(t3 as isize) + *c1.offset(t4 as isize);
@@ -1634,66 +1616,66 @@ unsafe extern "C" fn dradbg(
         }
         j += 1
     }
-    if !(ido == 1 as libc::c_int) {
+    if !(ido == 1 as c_int) {
         if nbd < l1 {
-            t1 = 0 as libc::c_int;
+            t1 = 0 as c_int;
             t2 = ipp2 * t0;
-            j = 1 as libc::c_int;
+            j = 1 as c_int;
             while j < ipph {
                 t1 += t0;
                 t2 -= t0;
                 t3 = t1;
                 t4 = t2;
-                i = 2 as libc::c_int;
+                i = 2 as c_int;
                 while i < ido {
-                    t3 += 2 as libc::c_int;
-                    t4 += 2 as libc::c_int;
+                    t3 += 2 as c_int;
+                    t4 += 2 as c_int;
                     t5 = t3;
                     t6 = t4;
-                    k = 0 as libc::c_int;
+                    k = 0 as c_int;
                     while k < l1 {
-                        *ch.offset((t5 - 1 as libc::c_int) as isize) =
-                            *c1.offset((t5 - 1 as libc::c_int) as isize) - *c1.offset(t6 as isize);
-                        *ch.offset((t6 - 1 as libc::c_int) as isize) =
-                            *c1.offset((t5 - 1 as libc::c_int) as isize) + *c1.offset(t6 as isize);
+                        *ch.offset((t5 - 1 as c_int) as isize) =
+                            *c1.offset((t5 - 1 as c_int) as isize) - *c1.offset(t6 as isize);
+                        *ch.offset((t6 - 1 as c_int) as isize) =
+                            *c1.offset((t5 - 1 as c_int) as isize) + *c1.offset(t6 as isize);
                         *ch.offset(t5 as isize) =
-                            *c1.offset(t5 as isize) + *c1.offset((t6 - 1 as libc::c_int) as isize);
+                            *c1.offset(t5 as isize) + *c1.offset((t6 - 1 as c_int) as isize);
                         *ch.offset(t6 as isize) =
-                            *c1.offset(t5 as isize) - *c1.offset((t6 - 1 as libc::c_int) as isize);
+                            *c1.offset(t5 as isize) - *c1.offset((t6 - 1 as c_int) as isize);
                         t5 += ido;
                         t6 += ido;
                         k += 1
                     }
-                    i += 2 as libc::c_int
+                    i += 2 as c_int
                 }
                 j += 1
             }
         } else {
-            t1 = 0 as libc::c_int;
+            t1 = 0 as c_int;
             t2 = ipp2 * t0;
-            j = 1 as libc::c_int;
+            j = 1 as c_int;
             while j < ipph {
                 t1 += t0;
                 t2 -= t0;
                 t3 = t1;
                 t4 = t2;
-                k = 0 as libc::c_int;
+                k = 0 as c_int;
                 while k < l1 {
                     t5 = t3;
                     t6 = t4;
-                    i = 2 as libc::c_int;
+                    i = 2 as c_int;
                     while i < ido {
-                        t5 += 2 as libc::c_int;
-                        t6 += 2 as libc::c_int;
-                        *ch.offset((t5 - 1 as libc::c_int) as isize) =
-                            *c1.offset((t5 - 1 as libc::c_int) as isize) - *c1.offset(t6 as isize);
-                        *ch.offset((t6 - 1 as libc::c_int) as isize) =
-                            *c1.offset((t5 - 1 as libc::c_int) as isize) + *c1.offset(t6 as isize);
+                        t5 += 2 as c_int;
+                        t6 += 2 as c_int;
+                        *ch.offset((t5 - 1 as c_int) as isize) =
+                            *c1.offset((t5 - 1 as c_int) as isize) - *c1.offset(t6 as isize);
+                        *ch.offset((t6 - 1 as c_int) as isize) =
+                            *c1.offset((t5 - 1 as c_int) as isize) + *c1.offset(t6 as isize);
                         *ch.offset(t5 as isize) =
-                            *c1.offset(t5 as isize) + *c1.offset((t6 - 1 as libc::c_int) as isize);
+                            *c1.offset(t5 as isize) + *c1.offset((t6 - 1 as c_int) as isize);
                         *ch.offset(t6 as isize) =
-                            *c1.offset(t5 as isize) - *c1.offset((t6 - 1 as libc::c_int) as isize);
-                        i += 2 as libc::c_int
+                            *c1.offset(t5 as isize) - *c1.offset((t6 - 1 as c_int) as isize);
+                        i += 2 as c_int
                     }
                     t3 += ido;
                     t4 += ido;
@@ -1703,20 +1685,20 @@ unsafe extern "C" fn dradbg(
             }
         }
     }
-    if ido == 1 as libc::c_int {
+    if ido == 1 as c_int {
         return;
     }
-    ik = 0 as libc::c_int;
+    ik = 0 as c_int;
     while ik < idl1 {
         *c2.offset(ik as isize) = *ch2.offset(ik as isize);
         ik += 1
     }
-    t1 = 0 as libc::c_int;
-    j = 1 as libc::c_int;
+    t1 = 0 as c_int;
+    j = 1 as c_int;
     while j < ip {
         t1 += t0;
         t2 = t1;
-        k = 0 as libc::c_int;
+        k = 0 as c_int;
         while k < l1 {
             *c1.offset(t2 as isize) = *ch.offset(t2 as isize);
             t2 += ido;
@@ -1725,29 +1707,29 @@ unsafe extern "C" fn dradbg(
         j += 1
     }
     if nbd > l1 {
-        is = -ido - 1 as libc::c_int;
-        t1 = 0 as libc::c_int;
-        j = 1 as libc::c_int;
+        is = -ido - 1 as c_int;
+        t1 = 0 as c_int;
+        j = 1 as c_int;
         while j < ip {
             is += ido;
             t1 += t0;
             t2 = t1;
-            k = 0 as libc::c_int;
+            k = 0 as c_int;
             while k < l1 {
                 idij = is;
                 t3 = t2;
-                i = 2 as libc::c_int;
+                i = 2 as c_int;
                 while i < ido {
-                    idij += 2 as libc::c_int;
-                    t3 += 2 as libc::c_int;
-                    *c1.offset((t3 - 1 as libc::c_int) as isize) = *wa
-                        .offset((idij - 1 as libc::c_int) as isize)
-                        * *ch.offset((t3 - 1 as libc::c_int) as isize)
+                    idij += 2 as c_int;
+                    t3 += 2 as c_int;
+                    *c1.offset((t3 - 1 as c_int) as isize) = *wa
+                        .offset((idij - 1 as c_int) as isize)
+                        * *ch.offset((t3 - 1 as c_int) as isize)
                         - *wa.offset(idij as isize) * *ch.offset(t3 as isize);
-                    *c1.offset(t3 as isize) = *wa.offset((idij - 1 as libc::c_int) as isize)
+                    *c1.offset(t3 as isize) = *wa.offset((idij - 1 as c_int) as isize)
                         * *ch.offset(t3 as isize)
-                        + *wa.offset(idij as isize) * *ch.offset((t3 - 1 as libc::c_int) as isize);
-                    i += 2 as libc::c_int
+                        + *wa.offset(idij as isize) * *ch.offset((t3 - 1 as c_int) as isize);
+                    i += 2 as c_int
                 }
                 t2 += ido;
                 k += 1
@@ -1756,32 +1738,32 @@ unsafe extern "C" fn dradbg(
         }
         return;
     } else {
-        is = -ido - 1 as libc::c_int;
-        t1 = 0 as libc::c_int;
-        j = 1 as libc::c_int;
+        is = -ido - 1 as c_int;
+        t1 = 0 as c_int;
+        j = 1 as c_int;
         while j < ip {
             is += ido;
             t1 += t0;
             idij = is;
             t2 = t1;
-            i = 2 as libc::c_int;
+            i = 2 as c_int;
             while i < ido {
-                t2 += 2 as libc::c_int;
-                idij += 2 as libc::c_int;
+                t2 += 2 as c_int;
+                idij += 2 as c_int;
                 t3 = t2;
-                k = 0 as libc::c_int;
+                k = 0 as c_int;
                 while k < l1 {
-                    *c1.offset((t3 - 1 as libc::c_int) as isize) = *wa
-                        .offset((idij - 1 as libc::c_int) as isize)
-                        * *ch.offset((t3 - 1 as libc::c_int) as isize)
+                    *c1.offset((t3 - 1 as c_int) as isize) = *wa
+                        .offset((idij - 1 as c_int) as isize)
+                        * *ch.offset((t3 - 1 as c_int) as isize)
                         - *wa.offset(idij as isize) * *ch.offset(t3 as isize);
-                    *c1.offset(t3 as isize) = *wa.offset((idij - 1 as libc::c_int) as isize)
+                    *c1.offset(t3 as isize) = *wa.offset((idij - 1 as c_int) as isize)
                         * *ch.offset(t3 as isize)
-                        + *wa.offset(idij as isize) * *ch.offset((t3 - 1 as libc::c_int) as isize);
+                        + *wa.offset(idij as isize) * *ch.offset((t3 - 1 as c_int) as isize);
                     t3 += ido;
                     k += 1
                 }
-                i += 2 as libc::c_int
+                i += 2 as c_int
             }
             j += 1
         }
@@ -1789,37 +1771,37 @@ unsafe extern "C" fn dradbg(
     };
 }
 unsafe extern "C" fn drftb1(
-    mut n: libc::c_int,
-    mut c: *mut libc::c_float,
-    mut ch: *mut libc::c_float,
-    mut wa: *mut libc::c_float,
-    mut ifac: *mut libc::c_int,
+    mut n: c_int,
+    mut c: *mut c_float,
+    mut ch: *mut c_float,
+    mut wa: *mut c_float,
+    mut ifac: *mut c_int,
 ) {
-    let mut i: libc::c_int = 0;
-    let mut k1: libc::c_int = 0;
-    let mut l1: libc::c_int = 0;
-    let mut l2: libc::c_int = 0;
-    let mut na: libc::c_int = 0;
-    let mut nf: libc::c_int = 0;
-    let mut ip: libc::c_int = 0;
-    let mut iw: libc::c_int = 0;
-    let mut ix2: libc::c_int = 0;
-    let mut ix3: libc::c_int = 0;
-    let mut ido: libc::c_int = 0;
-    let mut idl1: libc::c_int = 0;
-    nf = *ifac.offset(1 as libc::c_int as isize);
-    na = 0 as libc::c_int;
-    l1 = 1 as libc::c_int;
-    iw = 1 as libc::c_int;
-    k1 = 0 as libc::c_int;
+    let mut i: c_int = 0;
+    let mut k1: c_int = 0;
+    let mut l1: c_int = 0;
+    let mut l2: c_int = 0;
+    let mut na: c_int = 0;
+    let mut nf: c_int = 0;
+    let mut ip: c_int = 0;
+    let mut iw: c_int = 0;
+    let mut ix2: c_int = 0;
+    let mut ix3: c_int = 0;
+    let mut ido: c_int = 0;
+    let mut idl1: c_int = 0;
+    nf = *ifac.offset(1 as c_int as isize);
+    na = 0 as c_int;
+    l1 = 1 as c_int;
+    iw = 1 as c_int;
+    k1 = 0 as c_int;
     while k1 < nf {
-        ip = *ifac.offset((k1 + 2 as libc::c_int) as isize);
+        ip = *ifac.offset((k1 + 2 as c_int) as isize);
         l2 = ip * l1;
         ido = n / l2;
         idl1 = ido * l1;
-        if ip != 4 as libc::c_int {
-            if ip != 2 as libc::c_int {
-                if ip != 3 as libc::c_int {
+        if ip != 4 as c_int {
+            if ip != 2 as c_int {
+                if ip != 3 as c_int {
                     /*    The radix five case can be translated later..... */
                     /*    if(ip!=5)goto L112;
 
@@ -1834,7 +1816,7 @@ unsafe extern "C" fn drftb1(
                       goto L115;
 
                     L112:*/
-                    if na != 0 as libc::c_int {
+                    if na != 0 as c_int {
                         dradbg(
                             ido,
                             ip,
@@ -1845,7 +1827,7 @@ unsafe extern "C" fn drftb1(
                             ch,
                             c,
                             c,
-                            wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
+                            wa.offset(iw as isize).offset(-(1 as c_int as isize)),
                         );
                     } else {
                         dradbg(
@@ -1858,22 +1840,22 @@ unsafe extern "C" fn drftb1(
                             c,
                             ch,
                             ch,
-                            wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
+                            wa.offset(iw as isize).offset(-(1 as c_int as isize)),
                         );
                     }
-                    if ido == 1 as libc::c_int {
-                        na = 1 as libc::c_int - na
+                    if ido == 1 as c_int {
+                        na = 1 as c_int - na
                     }
                 } else {
                     ix2 = iw + ido;
-                    if na != 0 as libc::c_int {
+                    if na != 0 as c_int {
                         dradb3(
                             ido,
                             l1,
                             ch,
                             c,
-                            wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
-                            wa.offset(ix2 as isize).offset(-(1 as libc::c_int as isize)),
+                            wa.offset(iw as isize).offset(-(1 as c_int as isize)),
+                            wa.offset(ix2 as isize).offset(-(1 as c_int as isize)),
                         );
                     } else {
                         dradb3(
@@ -1881,20 +1863,20 @@ unsafe extern "C" fn drftb1(
                             l1,
                             c,
                             ch,
-                            wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
-                            wa.offset(ix2 as isize).offset(-(1 as libc::c_int as isize)),
+                            wa.offset(iw as isize).offset(-(1 as c_int as isize)),
+                            wa.offset(ix2 as isize).offset(-(1 as c_int as isize)),
                         );
                     }
-                    na = 1 as libc::c_int - na
+                    na = 1 as c_int - na
                 }
             } else {
-                if na != 0 as libc::c_int {
+                if na != 0 as c_int {
                     dradb2(
                         ido,
                         l1,
                         ch,
                         c,
-                        wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
+                        wa.offset(iw as isize).offset(-(1 as c_int as isize)),
                     );
                 } else {
                     dradb2(
@@ -1902,23 +1884,23 @@ unsafe extern "C" fn drftb1(
                         l1,
                         c,
                         ch,
-                        wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
+                        wa.offset(iw as isize).offset(-(1 as c_int as isize)),
                     );
                 }
-                na = 1 as libc::c_int - na
+                na = 1 as c_int - na
             }
         } else {
             ix2 = iw + ido;
             ix3 = ix2 + ido;
-            if na != 0 as libc::c_int {
+            if na != 0 as c_int {
                 dradb4(
                     ido,
                     l1,
                     ch,
                     c,
-                    wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
-                    wa.offset(ix2 as isize).offset(-(1 as libc::c_int as isize)),
-                    wa.offset(ix3 as isize).offset(-(1 as libc::c_int as isize)),
+                    wa.offset(iw as isize).offset(-(1 as c_int as isize)),
+                    wa.offset(ix2 as isize).offset(-(1 as c_int as isize)),
+                    wa.offset(ix3 as isize).offset(-(1 as c_int as isize)),
                 );
             } else {
                 dradb4(
@@ -1926,29 +1908,29 @@ unsafe extern "C" fn drftb1(
                     l1,
                     c,
                     ch,
-                    wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
-                    wa.offset(ix2 as isize).offset(-(1 as libc::c_int as isize)),
-                    wa.offset(ix3 as isize).offset(-(1 as libc::c_int as isize)),
+                    wa.offset(iw as isize).offset(-(1 as c_int as isize)),
+                    wa.offset(ix2 as isize).offset(-(1 as c_int as isize)),
+                    wa.offset(ix3 as isize).offset(-(1 as c_int as isize)),
                 );
             }
-            na = 1 as libc::c_int - na
+            na = 1 as c_int - na
         }
         l1 = l2;
-        iw += (ip - 1 as libc::c_int) * ido;
+        iw += (ip - 1 as c_int) * ido;
         k1 += 1
     }
-    if na == 0 as libc::c_int {
+    if na == 0 as c_int {
         return;
     }
-    i = 0 as libc::c_int;
+    i = 0 as c_int;
     while i < n {
         *c.offset(i as isize) = *ch.offset(i as isize);
         i += 1
     }
 }
 #[no_mangle]
-pub unsafe extern "C" fn spx_drft_forward(mut l: *mut drft_lookup, mut data: *mut libc::c_float) {
-    if (*l).n == 1 as libc::c_int {
+pub unsafe extern "C" fn spx_drft_forward(mut l: *mut drft_lookup, mut data: *mut c_float) {
+    if (*l).n == 1 as c_int {
         return;
     }
     drftf1(
@@ -1960,8 +1942,8 @@ pub unsafe extern "C" fn spx_drft_forward(mut l: *mut drft_lookup, mut data: *mu
     );
 }
 #[no_mangle]
-pub unsafe extern "C" fn spx_drft_backward(mut l: *mut drft_lookup, mut data: *mut libc::c_float) {
-    if (*l).n == 1 as libc::c_int {
+pub unsafe extern "C" fn spx_drft_backward(mut l: *mut drft_lookup, mut data: *mut c_float) {
+    if (*l).n == 1 as c_int {
         return;
     }
     drftb1(
@@ -1973,28 +1955,25 @@ pub unsafe extern "C" fn spx_drft_backward(mut l: *mut drft_lookup, mut data: *m
     );
 }
 #[no_mangle]
-pub unsafe extern "C" fn spx_drft_init(mut l: *mut drft_lookup, mut n: libc::c_int) {
+pub unsafe extern "C" fn spx_drft_init(mut l: *mut drft_lookup, mut n: c_int) {
     (*l).n = n;
     (*l).trigcache = speex_alloc(
-        ((3 as libc::c_int * n) as libc::c_ulong)
-            .wrapping_mul(::std::mem::size_of::<libc::c_float>() as libc::c_ulong)
-            as libc::c_int,
-    ) as *mut libc::c_float;
+        ((3 as c_int * n) as c_ulong).wrapping_mul(::std::mem::size_of::<c_float>() as c_ulong)
+            as c_int,
+    ) as *mut c_float;
     (*l).splitcache = speex_alloc(
-        (32 as libc::c_int as libc::c_ulong)
-            .wrapping_mul(::std::mem::size_of::<libc::c_int>() as libc::c_ulong)
-            as libc::c_int,
-    ) as *mut libc::c_int;
+        (32 as c_int as c_ulong).wrapping_mul(::std::mem::size_of::<c_int>() as c_ulong) as c_int,
+    ) as *mut c_int;
     fdrffti(n, (*l).trigcache, (*l).splitcache);
 }
 #[no_mangle]
 pub unsafe extern "C" fn spx_drft_clear(mut l: *mut drft_lookup) {
     if !l.is_null() {
         if !(*l).trigcache.is_null() {
-            speex_free((*l).trigcache as *mut libc::c_void);
+            speex_free((*l).trigcache as *mut c_void);
         }
         if !(*l).splitcache.is_null() {
-            speex_free((*l).splitcache as *mut libc::c_void);
+            speex_free((*l).splitcache as *mut c_void);
         }
     };
 }

--- a/fft/src/smallft.rs
+++ b/fft/src/smallft.rs
@@ -11,21 +11,21 @@ extern "C" {
     fn free(__ptr: *mut libc::c_void);
 }
 /* *******************************************************************
- *                                                                  *
- * THIS FILE IS PART OF THE OggVorbis SOFTWARE CODEC SOURCE CODE.   *
- * USE, DISTRIBUTION AND REPRODUCTION OF THIS LIBRARY SOURCE IS     *
- * GOVERNED BY A BSD-STYLE SOURCE LICENSE INCLUDED WITH THIS SOURCE *
- * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
- *                                                                  *
- * THE OggVorbis SOURCE CODE IS (C) COPYRIGHT 1994-2001             *
- * by the XIPHOPHORUS Company http://www.xiph.org/                  *
- *                                                                  *
- ********************************************************************
+*                                                                  *
+* THIS FILE IS PART OF THE OggVorbis SOFTWARE CODEC SOURCE CODE.   *
+* USE, DISTRIBUTION AND REPRODUCTION OF THIS LIBRARY SOURCE IS     *
+* GOVERNED BY A BSD-STYLE SOURCE LICENSE INCLUDED WITH THIS SOURCE *
+* IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
+*                                                                  *
+* THE OggVorbis SOURCE CODE IS (C) COPYRIGHT 1994-2001             *
+* by the XIPHOPHORUS Company http://www.xiph.org/                  *
+*                                                                  *
+********************************************************************
 
- function: fft transform
- last mod: $Id: smallft.h,v 1.3 2003/09/16 18:35:45 jm Exp $
+function: fft transform
+last mod: $Id: smallft.h,v 1.3 2003/09/16 18:35:45 jm Exp $
 
- ********************************************************************/
+********************************************************************/
 /* *
    @file smallft.h
    @brief Discrete Rotational Fourier Transform (DRFT)
@@ -43,23 +43,25 @@ unsafe extern "C" fn speex_alloc(mut size: libc::c_int) -> *mut libc::c_void {
     return calloc(size as libc::c_ulong, 1 as libc::c_int as libc::c_ulong);
 }
 #[inline]
-unsafe extern "C" fn speex_free(mut ptr: *mut libc::c_void) { free(ptr); }
+unsafe extern "C" fn speex_free(mut ptr: *mut libc::c_void) {
+    free(ptr);
+}
 /* *******************************************************************
- *                                                                  *
- * THIS FILE IS PART OF THE OggVorbis SOFTWARE CODEC SOURCE CODE.   *
- * USE, DISTRIBUTION AND REPRODUCTION OF THIS LIBRARY SOURCE IS     *
- * GOVERNED BY A BSD-STYLE SOURCE LICENSE INCLUDED WITH THIS SOURCE *
- * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
- *                                                                  *
- * THE OggVorbis SOURCE CODE IS (C) COPYRIGHT 1994-2001             *
- * by the XIPHOPHORUS Company http://www.xiph.org/                  *
- *                                                                  *
- ********************************************************************
+*                                                                  *
+* THIS FILE IS PART OF THE OggVorbis SOFTWARE CODEC SOURCE CODE.   *
+* USE, DISTRIBUTION AND REPRODUCTION OF THIS LIBRARY SOURCE IS     *
+* GOVERNED BY A BSD-STYLE SOURCE LICENSE INCLUDED WITH THIS SOURCE *
+* IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
+*                                                                  *
+* THE OggVorbis SOURCE CODE IS (C) COPYRIGHT 1994-2001             *
+* by the XIPHOPHORUS Company http://www.xiph.org/                  *
+*                                                                  *
+********************************************************************
 
- function: *unnormalized* fft transform
- last mod: $Id: smallft.c,v 1.19 2003/10/08 05:12:37 jm Exp $
+function: *unnormalized* fft transform
+last mod: $Id: smallft.c,v 1.19 2003/10/08 05:12:37 jm Exp $
 
- ********************************************************************/
+********************************************************************/
 /* FFT implementation from OggSquish, minus cosine transforms,
  * minus all but radix 2/4 case.  In Vorbis we only need this
  * cut-down version.
@@ -72,11 +74,17 @@ unsafe extern "C" fn speex_free(mut ptr: *mut libc::c_void) { free(ptr); }
  * it follows R_0, R_1, I_1, R_2, I_2 ... R_n-1, I_n-1, I_n like the
  * FORTRAN version
  */
-unsafe extern "C" fn drfti1(mut n: libc::c_int, mut wa: *mut libc::c_float,
-                            mut ifac: *mut libc::c_int) {
-    static mut ntryh: [libc::c_int; 4] =
-        [4 as libc::c_int, 2 as libc::c_int, 3 as libc::c_int,
-         5 as libc::c_int];
+unsafe extern "C" fn drfti1(
+    mut n: libc::c_int,
+    mut wa: *mut libc::c_float,
+    mut ifac: *mut libc::c_int,
+) {
+    static mut ntryh: [libc::c_int; 4] = [
+        4 as libc::c_int,
+        2 as libc::c_int,
+        3 as libc::c_int,
+        5 as libc::c_int,
+    ];
     static mut tpi: libc::c_float = 6.28318530717958648f32;
     let mut arg: libc::c_float = 0.;
     let mut argh: libc::c_float = 0.;
@@ -100,42 +108,47 @@ unsafe extern "C" fn drfti1(mut n: libc::c_int, mut wa: *mut libc::c_float,
     let mut nfm1: libc::c_int = 0;
     let mut nl: libc::c_int = n;
     let mut nf: libc::c_int = 0 as libc::c_int;
-    'c_10244:
-        loop  {
-            j += 1;
-            if j < 4 as libc::c_int {
-                ntry = ntryh[j as usize]
-            } else { ntry += 2 as libc::c_int }
-            loop  {
-                nq = nl / ntry;
-                nr = nl - ntry * nq;
-                if nr != 0 as libc::c_int { break ; }
-                nf += 1;
-                *ifac.offset((nf + 1 as libc::c_int) as isize) = ntry;
-                nl = nq;
-                if !(ntry != 2 as libc::c_int) {
-                    if !(nf == 1 as libc::c_int) {
-                        i = 1 as libc::c_int;
-                        while i < nf {
-                            ib = nf - i + 1 as libc::c_int;
-                            *ifac.offset((ib + 1 as libc::c_int) as isize) =
-                                *ifac.offset(ib as isize);
-                            i += 1
-                        }
-                        *ifac.offset(2 as libc::c_int as isize) =
-                            2 as libc::c_int
+    'c_10244: loop {
+        j += 1;
+        if j < 4 as libc::c_int {
+            ntry = ntryh[j as usize]
+        } else {
+            ntry += 2 as libc::c_int
+        }
+        loop {
+            nq = nl / ntry;
+            nr = nl - ntry * nq;
+            if nr != 0 as libc::c_int {
+                break;
+            }
+            nf += 1;
+            *ifac.offset((nf + 1 as libc::c_int) as isize) = ntry;
+            nl = nq;
+            if !(ntry != 2 as libc::c_int) {
+                if !(nf == 1 as libc::c_int) {
+                    i = 1 as libc::c_int;
+                    while i < nf {
+                        ib = nf - i + 1 as libc::c_int;
+                        *ifac.offset((ib + 1 as libc::c_int) as isize) = *ifac.offset(ib as isize);
+                        i += 1
                     }
+                    *ifac.offset(2 as libc::c_int as isize) = 2 as libc::c_int
                 }
-                if !(nl != 1 as libc::c_int) { break 'c_10244 ; }
+            }
+            if !(nl != 1 as libc::c_int) {
+                break 'c_10244;
             }
         }
+    }
     *ifac.offset(0 as libc::c_int as isize) = n;
     *ifac.offset(1 as libc::c_int as isize) = nf;
     argh = tpi / n as libc::c_float;
     is = 0 as libc::c_int;
     nfm1 = nf - 1 as libc::c_int;
     l1 = 1 as libc::c_int;
-    if nfm1 == 0 as libc::c_int { return }
+    if nfm1 == 0 as libc::c_int {
+        return;
+    }
     k1 = 0 as libc::c_int;
     while k1 < nfm1 {
         ip = *ifac.offset((k1 + 2 as libc::c_int) as isize);
@@ -155,12 +168,10 @@ unsafe extern "C" fn drfti1(mut n: libc::c_int, mut wa: *mut libc::c_float,
                 arg = fi * argld;
                 let fresh0 = i;
                 i = i + 1;
-                *wa.offset(fresh0 as isize) =
-                    cos(arg as libc::c_double) as libc::c_float;
+                *wa.offset(fresh0 as isize) = cos(arg as libc::c_double) as libc::c_float;
                 let fresh1 = i;
                 i = i + 1;
-                *wa.offset(fresh1 as isize) =
-                    sin(arg as libc::c_double) as libc::c_float;
+                *wa.offset(fresh1 as isize) = sin(arg as libc::c_double) as libc::c_float;
                 ii += 2 as libc::c_int
             }
             is += ido;
@@ -168,18 +179,25 @@ unsafe extern "C" fn drfti1(mut n: libc::c_int, mut wa: *mut libc::c_float,
         }
         l1 = l2;
         k1 += 1
-    };
+    }
 }
-unsafe extern "C" fn fdrffti(mut n: libc::c_int,
-                             mut wsave: *mut libc::c_float,
-                             mut ifac: *mut libc::c_int) {
-    if n == 1 as libc::c_int { return }
+unsafe extern "C" fn fdrffti(
+    mut n: libc::c_int,
+    mut wsave: *mut libc::c_float,
+    mut ifac: *mut libc::c_int,
+) {
+    if n == 1 as libc::c_int {
+        return;
+    }
     drfti1(n, wsave.offset(n as isize), ifac);
 }
-unsafe extern "C" fn dradf2(mut ido: libc::c_int, mut l1: libc::c_int,
-                            mut cc: *mut libc::c_float,
-                            mut ch: *mut libc::c_float,
-                            mut wa1: *mut libc::c_float) {
+unsafe extern "C" fn dradf2(
+    mut ido: libc::c_int,
+    mut l1: libc::c_int,
+    mut cc: *mut libc::c_float,
+    mut ch: *mut libc::c_float,
+    mut wa1: *mut libc::c_float,
+) {
     let mut i: libc::c_int = 0;
     let mut k: libc::c_int = 0;
     let mut ti2: libc::c_float = 0.;
@@ -199,14 +217,15 @@ unsafe extern "C" fn dradf2(mut ido: libc::c_int, mut l1: libc::c_int,
     while k < l1 {
         *ch.offset((t1 << 1 as libc::c_int) as isize) =
             *cc.offset(t1 as isize) + *cc.offset(t2 as isize);
-        *ch.offset(((t1 << 1 as libc::c_int) + t3 - 1 as libc::c_int) as
-                       isize) =
+        *ch.offset(((t1 << 1 as libc::c_int) + t3 - 1 as libc::c_int) as isize) =
             *cc.offset(t1 as isize) - *cc.offset(t2 as isize);
         t1 += ido;
         t2 += ido;
         k += 1
     }
-    if ido < 2 as libc::c_int { return }
+    if ido < 2 as libc::c_int {
+        return;
+    }
     if !(ido == 2 as libc::c_int) {
         t1 = 0 as libc::c_int;
         t2 = t0;
@@ -222,16 +241,12 @@ unsafe extern "C" fn dradf2(mut ido: libc::c_int, mut l1: libc::c_int,
                 t4 -= 2 as libc::c_int;
                 t5 += 2 as libc::c_int;
                 t6 += 2 as libc::c_int;
-                tr2 =
-                    *wa1.offset((i - 2 as libc::c_int) as isize) *
-                        *cc.offset((t3 - 1 as libc::c_int) as isize) +
-                        *wa1.offset((i - 1 as libc::c_int) as isize) *
-                            *cc.offset(t3 as isize);
-                ti2 =
-                    *wa1.offset((i - 2 as libc::c_int) as isize) *
-                        *cc.offset(t3 as isize) -
-                        *wa1.offset((i - 1 as libc::c_int) as isize) *
-                            *cc.offset((t3 - 1 as libc::c_int) as isize);
+                tr2 = *wa1.offset((i - 2 as libc::c_int) as isize)
+                    * *cc.offset((t3 - 1 as libc::c_int) as isize)
+                    + *wa1.offset((i - 1 as libc::c_int) as isize) * *cc.offset(t3 as isize);
+                ti2 = *wa1.offset((i - 2 as libc::c_int) as isize) * *cc.offset(t3 as isize)
+                    - *wa1.offset((i - 1 as libc::c_int) as isize)
+                        * *cc.offset((t3 - 1 as libc::c_int) as isize);
                 *ch.offset(t6 as isize) = *cc.offset(t5 as isize) + ti2;
                 *ch.offset(t4 as isize) = ti2 - *cc.offset(t5 as isize);
                 *ch.offset((t6 - 1 as libc::c_int) as isize) =
@@ -244,7 +259,9 @@ unsafe extern "C" fn dradf2(mut ido: libc::c_int, mut l1: libc::c_int,
             t2 += ido;
             k += 1
         }
-        if ido % 2 as libc::c_int == 1 as libc::c_int { return }
+        if ido % 2 as libc::c_int == 1 as libc::c_int {
+            return;
+        }
     }
     t1 = ido;
     t2 = t1 - 1 as libc::c_int;
@@ -253,20 +270,22 @@ unsafe extern "C" fn dradf2(mut ido: libc::c_int, mut l1: libc::c_int,
     k = 0 as libc::c_int;
     while k < l1 {
         *ch.offset(t1 as isize) = -*cc.offset(t2 as isize);
-        *ch.offset((t1 - 1 as libc::c_int) as isize) =
-            *cc.offset(t3 as isize);
+        *ch.offset((t1 - 1 as libc::c_int) as isize) = *cc.offset(t3 as isize);
         t1 += ido << 1 as libc::c_int;
         t2 += ido;
         t3 += ido;
         k += 1
-    };
+    }
 }
-unsafe extern "C" fn dradf4(mut ido: libc::c_int, mut l1: libc::c_int,
-                            mut cc: *mut libc::c_float,
-                            mut ch: *mut libc::c_float,
-                            mut wa1: *mut libc::c_float,
-                            mut wa2: *mut libc::c_float,
-                            mut wa3: *mut libc::c_float) {
+unsafe extern "C" fn dradf4(
+    mut ido: libc::c_int,
+    mut l1: libc::c_int,
+    mut cc: *mut libc::c_float,
+    mut ch: *mut libc::c_float,
+    mut wa1: *mut libc::c_float,
+    mut wa2: *mut libc::c_float,
+    mut wa3: *mut libc::c_float,
+) {
     static mut hsqt2: libc::c_float = 0.70710678118654752f32;
     let mut i: libc::c_int = 0;
     let mut k: libc::c_int = 0;
@@ -302,20 +321,20 @@ unsafe extern "C" fn dradf4(mut ido: libc::c_int, mut l1: libc::c_int,
         tr2 = *cc.offset(t3 as isize) + *cc.offset(t4 as isize);
         t5 = t3 << 2 as libc::c_int;
         *ch.offset(t5 as isize) = tr1 + tr2;
-        *ch.offset(((ido << 2 as libc::c_int) + t5 - 1 as libc::c_int) as
-                       isize) = tr2 - tr1;
+        *ch.offset(((ido << 2 as libc::c_int) + t5 - 1 as libc::c_int) as isize) = tr2 - tr1;
         t5 += ido << 1 as libc::c_int;
         *ch.offset((t5 - 1 as libc::c_int) as isize) =
             *cc.offset(t3 as isize) - *cc.offset(t4 as isize);
-        *ch.offset(t5 as isize) =
-            *cc.offset(t2 as isize) - *cc.offset(t1 as isize);
+        *ch.offset(t5 as isize) = *cc.offset(t2 as isize) - *cc.offset(t1 as isize);
         t1 += ido;
         t2 += ido;
         t3 += ido;
         t4 += ido;
         k += 1
     }
-    if ido < 2 as libc::c_int { return }
+    if ido < 2 as libc::c_int {
+        return;
+    }
     if !(ido == 2 as libc::c_int) {
         t1 = 0 as libc::c_int;
         k = 0 as libc::c_int;
@@ -331,38 +350,26 @@ unsafe extern "C" fn dradf4(mut ido: libc::c_int, mut l1: libc::c_int,
                 t4 += 2 as libc::c_int;
                 t5 -= 2 as libc::c_int;
                 t3 += t0;
-                cr2 =
-                    *wa1.offset((i - 2 as libc::c_int) as isize) *
-                        *cc.offset((t3 - 1 as libc::c_int) as isize) +
-                        *wa1.offset((i - 1 as libc::c_int) as isize) *
-                            *cc.offset(t3 as isize);
-                ci2 =
-                    *wa1.offset((i - 2 as libc::c_int) as isize) *
-                        *cc.offset(t3 as isize) -
-                        *wa1.offset((i - 1 as libc::c_int) as isize) *
-                            *cc.offset((t3 - 1 as libc::c_int) as isize);
+                cr2 = *wa1.offset((i - 2 as libc::c_int) as isize)
+                    * *cc.offset((t3 - 1 as libc::c_int) as isize)
+                    + *wa1.offset((i - 1 as libc::c_int) as isize) * *cc.offset(t3 as isize);
+                ci2 = *wa1.offset((i - 2 as libc::c_int) as isize) * *cc.offset(t3 as isize)
+                    - *wa1.offset((i - 1 as libc::c_int) as isize)
+                        * *cc.offset((t3 - 1 as libc::c_int) as isize);
                 t3 += t0;
-                cr3 =
-                    *wa2.offset((i - 2 as libc::c_int) as isize) *
-                        *cc.offset((t3 - 1 as libc::c_int) as isize) +
-                        *wa2.offset((i - 1 as libc::c_int) as isize) *
-                            *cc.offset(t3 as isize);
-                ci3 =
-                    *wa2.offset((i - 2 as libc::c_int) as isize) *
-                        *cc.offset(t3 as isize) -
-                        *wa2.offset((i - 1 as libc::c_int) as isize) *
-                            *cc.offset((t3 - 1 as libc::c_int) as isize);
+                cr3 = *wa2.offset((i - 2 as libc::c_int) as isize)
+                    * *cc.offset((t3 - 1 as libc::c_int) as isize)
+                    + *wa2.offset((i - 1 as libc::c_int) as isize) * *cc.offset(t3 as isize);
+                ci3 = *wa2.offset((i - 2 as libc::c_int) as isize) * *cc.offset(t3 as isize)
+                    - *wa2.offset((i - 1 as libc::c_int) as isize)
+                        * *cc.offset((t3 - 1 as libc::c_int) as isize);
                 t3 += t0;
-                cr4 =
-                    *wa3.offset((i - 2 as libc::c_int) as isize) *
-                        *cc.offset((t3 - 1 as libc::c_int) as isize) +
-                        *wa3.offset((i - 1 as libc::c_int) as isize) *
-                            *cc.offset(t3 as isize);
-                ci4 =
-                    *wa3.offset((i - 2 as libc::c_int) as isize) *
-                        *cc.offset(t3 as isize) -
-                        *wa3.offset((i - 1 as libc::c_int) as isize) *
-                            *cc.offset((t3 - 1 as libc::c_int) as isize);
+                cr4 = *wa3.offset((i - 2 as libc::c_int) as isize)
+                    * *cc.offset((t3 - 1 as libc::c_int) as isize)
+                    + *wa3.offset((i - 1 as libc::c_int) as isize) * *cc.offset(t3 as isize);
+                ci4 = *wa3.offset((i - 2 as libc::c_int) as isize) * *cc.offset(t3 as isize)
+                    - *wa3.offset((i - 1 as libc::c_int) as isize)
+                        * *cc.offset((t3 - 1 as libc::c_int) as isize);
                 tr1 = cr2 + cr4;
                 tr4 = cr4 - cr2;
                 ti1 = ci2 + ci4;
@@ -384,7 +391,9 @@ unsafe extern "C" fn dradf4(mut ido: libc::c_int, mut l1: libc::c_int,
             t1 += ido;
             k += 1
         }
-        if ido & 1 as libc::c_int != 0 { return }
+        if ido & 1 as libc::c_int != 0 {
+            return;
+        }
     }
     t1 = t0 + ido - 1 as libc::c_int;
     t2 = t1 + (t0 << 1 as libc::c_int);
@@ -407,16 +416,20 @@ unsafe extern "C" fn dradf4(mut ido: libc::c_int, mut l1: libc::c_int,
         t4 += t3;
         t6 += ido;
         k += 1
-    };
+    }
 }
-unsafe extern "C" fn dradfg(mut ido: libc::c_int, mut ip: libc::c_int,
-                            mut l1: libc::c_int, mut idl1: libc::c_int,
-                            mut cc: *mut libc::c_float,
-                            mut c1: *mut libc::c_float,
-                            mut c2: *mut libc::c_float,
-                            mut ch: *mut libc::c_float,
-                            mut ch2: *mut libc::c_float,
-                            mut wa: *mut libc::c_float) {
+unsafe extern "C" fn dradfg(
+    mut ido: libc::c_int,
+    mut ip: libc::c_int,
+    mut l1: libc::c_int,
+    mut idl1: libc::c_int,
+    mut cc: *mut libc::c_float,
+    mut c1: *mut libc::c_float,
+    mut c2: *mut libc::c_float,
+    mut ch: *mut libc::c_float,
+    mut ch2: *mut libc::c_float,
+    mut wa: *mut libc::c_float,
+) {
     static mut tpi: libc::c_float = 6.283185307179586f32;
     let mut idij: libc::c_int = 0;
     let mut ipph: libc::c_int = 0;
@@ -497,17 +510,14 @@ unsafe extern "C" fn dradfg(mut ido: libc::c_int, mut ip: libc::c_int,
                     while i < ido {
                         idij += 2 as libc::c_int;
                         t3 += 2 as libc::c_int;
-                        *ch.offset((t3 - 1 as libc::c_int) as isize) =
-                            *wa.offset((idij - 1 as libc::c_int) as isize) *
-                                *c1.offset((t3 - 1 as libc::c_int) as isize) +
-                                *wa.offset(idij as isize) *
-                                    *c1.offset(t3 as isize);
-                        *ch.offset(t3 as isize) =
-                            *wa.offset((idij - 1 as libc::c_int) as isize) *
-                                *c1.offset(t3 as isize) -
-                                *wa.offset(idij as isize) *
-                                    *c1.offset((t3 - 1 as libc::c_int) as
-                                                   isize);
+                        *ch.offset((t3 - 1 as libc::c_int) as isize) = *wa
+                            .offset((idij - 1 as libc::c_int) as isize)
+                            * *c1.offset((t3 - 1 as libc::c_int) as isize)
+                            + *wa.offset(idij as isize) * *c1.offset(t3 as isize);
+                        *ch.offset(t3 as isize) = *wa.offset((idij - 1 as libc::c_int) as isize)
+                            * *c1.offset(t3 as isize)
+                            - *wa.offset(idij as isize)
+                                * *c1.offset((t3 - 1 as libc::c_int) as isize);
                         i += 2 as libc::c_int
                     }
                     k += 1
@@ -528,17 +538,14 @@ unsafe extern "C" fn dradfg(mut ido: libc::c_int, mut ip: libc::c_int,
                     t3 = t2;
                     k = 0 as libc::c_int;
                     while k < l1 {
-                        *ch.offset((t3 - 1 as libc::c_int) as isize) =
-                            *wa.offset((idij - 1 as libc::c_int) as isize) *
-                                *c1.offset((t3 - 1 as libc::c_int) as isize) +
-                                *wa.offset(idij as isize) *
-                                    *c1.offset(t3 as isize);
-                        *ch.offset(t3 as isize) =
-                            *wa.offset((idij - 1 as libc::c_int) as isize) *
-                                *c1.offset(t3 as isize) -
-                                *wa.offset(idij as isize) *
-                                    *c1.offset((t3 - 1 as libc::c_int) as
-                                                   isize);
+                        *ch.offset((t3 - 1 as libc::c_int) as isize) = *wa
+                            .offset((idij - 1 as libc::c_int) as isize)
+                            * *c1.offset((t3 - 1 as libc::c_int) as isize)
+                            + *wa.offset(idij as isize) * *c1.offset(t3 as isize);
+                        *ch.offset(t3 as isize) = *wa.offset((idij - 1 as libc::c_int) as isize)
+                            * *c1.offset(t3 as isize)
+                            - *wa.offset(idij as isize)
+                                * *c1.offset((t3 - 1 as libc::c_int) as isize);
                         t3 += ido;
                         k += 1
                     }
@@ -566,16 +573,14 @@ unsafe extern "C" fn dradfg(mut ido: libc::c_int, mut ip: libc::c_int,
                     while k < l1 {
                         t5 += ido;
                         t6 += ido;
-                        *c1.offset((t5 - 1 as libc::c_int) as isize) =
-                            *ch.offset((t5 - 1 as libc::c_int) as isize) +
-                                *ch.offset((t6 - 1 as libc::c_int) as isize);
+                        *c1.offset((t5 - 1 as libc::c_int) as isize) = *ch
+                            .offset((t5 - 1 as libc::c_int) as isize)
+                            + *ch.offset((t6 - 1 as libc::c_int) as isize);
                         *c1.offset((t6 - 1 as libc::c_int) as isize) =
                             *ch.offset(t5 as isize) - *ch.offset(t6 as isize);
-                        *c1.offset(t5 as isize) =
-                            *ch.offset(t5 as isize) + *ch.offset(t6 as isize);
-                        *c1.offset(t6 as isize) =
-                            *ch.offset((t6 - 1 as libc::c_int) as isize) -
-                                *ch.offset((t5 - 1 as libc::c_int) as isize);
+                        *c1.offset(t5 as isize) = *ch.offset(t5 as isize) + *ch.offset(t6 as isize);
+                        *c1.offset(t6 as isize) = *ch.offset((t6 - 1 as libc::c_int) as isize)
+                            - *ch.offset((t5 - 1 as libc::c_int) as isize);
                         k += 1
                     }
                     i += 2 as libc::c_int
@@ -597,16 +602,14 @@ unsafe extern "C" fn dradfg(mut ido: libc::c_int, mut ip: libc::c_int,
                     while i < ido {
                         t5 += 2 as libc::c_int;
                         t6 += 2 as libc::c_int;
-                        *c1.offset((t5 - 1 as libc::c_int) as isize) =
-                            *ch.offset((t5 - 1 as libc::c_int) as isize) +
-                                *ch.offset((t6 - 1 as libc::c_int) as isize);
+                        *c1.offset((t5 - 1 as libc::c_int) as isize) = *ch
+                            .offset((t5 - 1 as libc::c_int) as isize)
+                            + *ch.offset((t6 - 1 as libc::c_int) as isize);
                         *c1.offset((t6 - 1 as libc::c_int) as isize) =
                             *ch.offset(t5 as isize) - *ch.offset(t6 as isize);
-                        *c1.offset(t5 as isize) =
-                            *ch.offset(t5 as isize) + *ch.offset(t6 as isize);
-                        *c1.offset(t6 as isize) =
-                            *ch.offset((t6 - 1 as libc::c_int) as isize) -
-                                *ch.offset((t5 - 1 as libc::c_int) as isize);
+                        *c1.offset(t5 as isize) = *ch.offset(t5 as isize) + *ch.offset(t6 as isize);
+                        *c1.offset(t6 as isize) = *ch.offset((t6 - 1 as libc::c_int) as isize)
+                            - *ch.offset((t5 - 1 as libc::c_int) as isize);
                         i += 2 as libc::c_int
                     }
                     t3 += ido;
@@ -634,10 +637,8 @@ unsafe extern "C" fn dradfg(mut ido: libc::c_int, mut ip: libc::c_int,
         while k < l1 {
             t3 += ido;
             t4 += ido;
-            *c1.offset(t3 as isize) =
-                *ch.offset(t3 as isize) + *ch.offset(t4 as isize);
-            *c1.offset(t4 as isize) =
-                *ch.offset(t4 as isize) - *ch.offset(t3 as isize);
+            *c1.offset(t3 as isize) = *ch.offset(t3 as isize) + *ch.offset(t4 as isize);
+            *c1.offset(t4 as isize) = *ch.offset(t4 as isize) - *ch.offset(t3 as isize);
             k += 1
         }
         j += 1
@@ -696,14 +697,12 @@ unsafe extern "C" fn dradfg(mut ido: libc::c_int, mut ip: libc::c_int,
                 t8 = t8 + 1;
                 let fresh7 = t6;
                 t6 = t6 + 1;
-                *ch2.offset(fresh7 as isize) +=
-                    ar2 * *c2.offset(fresh6 as isize);
+                *ch2.offset(fresh7 as isize) += ar2 * *c2.offset(fresh6 as isize);
                 let fresh8 = t9;
                 t9 = t9 + 1;
                 let fresh9 = t7;
                 t7 = t7 + 1;
-                *ch2.offset(fresh9 as isize) +=
-                    ai2 * *c2.offset(fresh8 as isize);
+                *ch2.offset(fresh9 as isize) += ai2 * *c2.offset(fresh8 as isize);
                 ik += 1
             }
             j += 1
@@ -773,8 +772,7 @@ unsafe extern "C" fn dradfg(mut ido: libc::c_int, mut ip: libc::c_int,
         t7 = t4;
         k = 0 as libc::c_int;
         while k < l1 {
-            *cc.offset((t5 - 1 as libc::c_int) as isize) =
-                *ch.offset(t6 as isize);
+            *cc.offset((t5 - 1 as libc::c_int) as isize) = *ch.offset(t6 as isize);
             *cc.offset(t5 as isize) = *ch.offset(t7 as isize);
             t5 += t10;
             t6 += ido;
@@ -783,7 +781,9 @@ unsafe extern "C" fn dradfg(mut ido: libc::c_int, mut ip: libc::c_int,
         }
         j += 1
     }
-    if ido == 1 as libc::c_int { return }
+    if ido == 1 as libc::c_int {
+        return;
+    }
     if nbd < l1 {
         t1 = -ido;
         t3 = 0 as libc::c_int;
@@ -803,16 +803,14 @@ unsafe extern "C" fn dradfg(mut ido: libc::c_int, mut ip: libc::c_int,
                 t9 = i + t5;
                 k = 0 as libc::c_int;
                 while k < l1 {
-                    *cc.offset((t7 - 1 as libc::c_int) as isize) =
-                        *ch.offset((t8 - 1 as libc::c_int) as isize) +
-                            *ch.offset((t9 - 1 as libc::c_int) as isize);
-                    *cc.offset((t6 - 1 as libc::c_int) as isize) =
-                        *ch.offset((t8 - 1 as libc::c_int) as isize) -
-                            *ch.offset((t9 - 1 as libc::c_int) as isize);
-                    *cc.offset(t7 as isize) =
-                        *ch.offset(t8 as isize) + *ch.offset(t9 as isize);
-                    *cc.offset(t6 as isize) =
-                        *ch.offset(t9 as isize) - *ch.offset(t8 as isize);
+                    *cc.offset((t7 - 1 as libc::c_int) as isize) = *ch
+                        .offset((t8 - 1 as libc::c_int) as isize)
+                        + *ch.offset((t9 - 1 as libc::c_int) as isize);
+                    *cc.offset((t6 - 1 as libc::c_int) as isize) = *ch
+                        .offset((t8 - 1 as libc::c_int) as isize)
+                        - *ch.offset((t9 - 1 as libc::c_int) as isize);
+                    *cc.offset(t7 as isize) = *ch.offset(t8 as isize) + *ch.offset(t9 as isize);
+                    *cc.offset(t6 as isize) = *ch.offset(t9 as isize) - *ch.offset(t8 as isize);
                     t6 += t10;
                     t7 += t10;
                     t8 += ido;
@@ -844,18 +842,16 @@ unsafe extern "C" fn dradfg(mut ido: libc::c_int, mut ip: libc::c_int,
                 i = 2 as libc::c_int;
                 while i < ido {
                     ic = idp2 - i;
-                    *cc.offset((i + t7 - 1 as libc::c_int) as isize) =
-                        *ch.offset((i + t8 - 1 as libc::c_int) as isize) +
-                            *ch.offset((i + t9 - 1 as libc::c_int) as isize);
-                    *cc.offset((ic + t6 - 1 as libc::c_int) as isize) =
-                        *ch.offset((i + t8 - 1 as libc::c_int) as isize) -
-                            *ch.offset((i + t9 - 1 as libc::c_int) as isize);
+                    *cc.offset((i + t7 - 1 as libc::c_int) as isize) = *ch
+                        .offset((i + t8 - 1 as libc::c_int) as isize)
+                        + *ch.offset((i + t9 - 1 as libc::c_int) as isize);
+                    *cc.offset((ic + t6 - 1 as libc::c_int) as isize) = *ch
+                        .offset((i + t8 - 1 as libc::c_int) as isize)
+                        - *ch.offset((i + t9 - 1 as libc::c_int) as isize);
                     *cc.offset((i + t7) as isize) =
-                        *ch.offset((i + t8) as isize) +
-                            *ch.offset((i + t9) as isize);
+                        *ch.offset((i + t8) as isize) + *ch.offset((i + t9) as isize);
                     *cc.offset((ic + t6) as isize) =
-                        *ch.offset((i + t9) as isize) -
-                            *ch.offset((i + t8) as isize);
+                        *ch.offset((i + t9) as isize) - *ch.offset((i + t8) as isize);
                     i += 2 as libc::c_int
                 }
                 t6 += t10;
@@ -866,13 +862,16 @@ unsafe extern "C" fn dradfg(mut ido: libc::c_int, mut ip: libc::c_int,
             }
             j += 1
         }
-        return
+        return;
     };
 }
-unsafe extern "C" fn drftf1(mut n: libc::c_int, mut c: *mut libc::c_float,
-                            mut ch: *mut libc::c_float,
-                            mut wa: *mut libc::c_float,
-                            mut ifac: *mut libc::c_int) {
+unsafe extern "C" fn drftf1(
+    mut n: libc::c_int,
+    mut c: *mut libc::c_float,
+    mut ch: *mut libc::c_float,
+    mut wa: *mut libc::c_float,
+    mut ifac: *mut libc::c_int,
+) {
     let mut i: libc::c_int = 0;
     let mut k1: libc::c_int = 0;
     let mut l1: libc::c_int = 0;
@@ -901,69 +900,99 @@ unsafe extern "C" fn drftf1(mut n: libc::c_int, mut c: *mut libc::c_float,
         na = 1 as libc::c_int - na;
         if ip != 4 as libc::c_int {
             if ip != 2 as libc::c_int {
-                if ido == 1 as libc::c_int { na = 1 as libc::c_int - na }
+                if ido == 1 as libc::c_int {
+                    na = 1 as libc::c_int - na
+                }
                 if na != 0 as libc::c_int {
-                    dradfg(ido, ip, l1, idl1, ch, ch, ch, c, c,
-                           wa.offset(iw as
-                                         isize).offset(-(1 as libc::c_int as
-                                                             isize)));
+                    dradfg(
+                        ido,
+                        ip,
+                        l1,
+                        idl1,
+                        ch,
+                        ch,
+                        ch,
+                        c,
+                        c,
+                        wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
+                    );
                     na = 0 as libc::c_int
                 } else {
-                    dradfg(ido, ip, l1, idl1, c, c, c, ch, ch,
-                           wa.offset(iw as
-                                         isize).offset(-(1 as libc::c_int as
-                                                             isize)));
+                    dradfg(
+                        ido,
+                        ip,
+                        l1,
+                        idl1,
+                        c,
+                        c,
+                        c,
+                        ch,
+                        ch,
+                        wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
+                    );
                     na = 1 as libc::c_int
                 }
             } else if na != 0 as libc::c_int {
-                dradf2(ido, l1, ch, c,
-                       wa.offset(iw as
-                                     isize).offset(-(1 as libc::c_int as
-                                                         isize)));
+                dradf2(
+                    ido,
+                    l1,
+                    ch,
+                    c,
+                    wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
+                );
             } else {
-                dradf2(ido, l1, c, ch,
-                       wa.offset(iw as
-                                     isize).offset(-(1 as libc::c_int as
-                                                         isize)));
+                dradf2(
+                    ido,
+                    l1,
+                    c,
+                    ch,
+                    wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
+                );
             }
         } else {
             ix2 = iw + ido;
             ix3 = ix2 + ido;
             if na != 0 as libc::c_int {
-                dradf4(ido, l1, ch, c,
-                       wa.offset(iw as
-                                     isize).offset(-(1 as libc::c_int as
-                                                         isize)),
-                       wa.offset(ix2 as
-                                     isize).offset(-(1 as libc::c_int as
-                                                         isize)),
-                       wa.offset(ix3 as
-                                     isize).offset(-(1 as libc::c_int as
-                                                         isize)));
+                dradf4(
+                    ido,
+                    l1,
+                    ch,
+                    c,
+                    wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
+                    wa.offset(ix2 as isize).offset(-(1 as libc::c_int as isize)),
+                    wa.offset(ix3 as isize).offset(-(1 as libc::c_int as isize)),
+                );
             } else {
-                dradf4(ido, l1, c, ch,
-                       wa.offset(iw as
-                                     isize).offset(-(1 as libc::c_int as
-                                                         isize)),
-                       wa.offset(ix2 as
-                                     isize).offset(-(1 as libc::c_int as
-                                                         isize)),
-                       wa.offset(ix3 as
-                                     isize).offset(-(1 as libc::c_int as
-                                                         isize)));
+                dradf4(
+                    ido,
+                    l1,
+                    c,
+                    ch,
+                    wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
+                    wa.offset(ix2 as isize).offset(-(1 as libc::c_int as isize)),
+                    wa.offset(ix3 as isize).offset(-(1 as libc::c_int as isize)),
+                );
             }
         }
         l2 = l1;
         k1 += 1
     }
-    if na == 1 as libc::c_int { return }
+    if na == 1 as libc::c_int {
+        return;
+    }
     i = 0 as libc::c_int;
-    while i < n { *c.offset(i as isize) = *ch.offset(i as isize); i += 1 };
+    while i < n {
+        *c.offset(i as isize) = *ch.offset(i as isize);
+        i += 1
+    }
 }
-unsafe extern "C" fn dradb2(mut ido: libc::c_int, mut l1: libc::c_int,
-                            mut cc: *mut libc::c_float,
-                            mut ch: *mut libc::c_float,
-                            mut wa1: *mut libc::c_float) {
+unsafe extern "C" fn dradb2(
+    mut ido: libc::c_int,
+    mut l1: libc::c_int,
+    mut cc: *mut libc::c_float,
+    mut ch: *mut libc::c_float,
+    mut wa1: *mut libc::c_float,
+) {
     let mut i: libc::c_int = 0;
     let mut k: libc::c_int = 0;
     let mut t0: libc::c_int = 0;
@@ -981,15 +1010,15 @@ unsafe extern "C" fn dradb2(mut ido: libc::c_int, mut l1: libc::c_int,
     t3 = (ido << 1 as libc::c_int) - 1 as libc::c_int;
     k = 0 as libc::c_int;
     while k < l1 {
-        *ch.offset(t1 as isize) =
-            *cc.offset(t2 as isize) + *cc.offset((t3 + t2) as isize);
-        *ch.offset((t1 + t0) as isize) =
-            *cc.offset(t2 as isize) - *cc.offset((t3 + t2) as isize);
+        *ch.offset(t1 as isize) = *cc.offset(t2 as isize) + *cc.offset((t3 + t2) as isize);
+        *ch.offset((t1 + t0) as isize) = *cc.offset(t2 as isize) - *cc.offset((t3 + t2) as isize);
         t1 += ido;
         t2 = t1 << 1 as libc::c_int;
         k += 1
     }
-    if ido < 2 as libc::c_int { return }
+    if ido < 2 as libc::c_int {
+        return;
+    }
     if !(ido == 2 as libc::c_int) {
         t1 = 0 as libc::c_int;
         t2 = 0 as libc::c_int;
@@ -1005,48 +1034,48 @@ unsafe extern "C" fn dradb2(mut ido: libc::c_int, mut l1: libc::c_int,
                 t4 += 2 as libc::c_int;
                 t5 -= 2 as libc::c_int;
                 t6 += 2 as libc::c_int;
-                *ch.offset((t3 - 1 as libc::c_int) as isize) =
-                    *cc.offset((t4 - 1 as libc::c_int) as isize) +
-                        *cc.offset((t5 - 1 as libc::c_int) as isize);
-                tr2 =
-                    *cc.offset((t4 - 1 as libc::c_int) as isize) -
-                        *cc.offset((t5 - 1 as libc::c_int) as isize);
-                *ch.offset(t3 as isize) =
-                    *cc.offset(t4 as isize) - *cc.offset(t5 as isize);
+                *ch.offset((t3 - 1 as libc::c_int) as isize) = *cc
+                    .offset((t4 - 1 as libc::c_int) as isize)
+                    + *cc.offset((t5 - 1 as libc::c_int) as isize);
+                tr2 = *cc.offset((t4 - 1 as libc::c_int) as isize)
+                    - *cc.offset((t5 - 1 as libc::c_int) as isize);
+                *ch.offset(t3 as isize) = *cc.offset(t4 as isize) - *cc.offset(t5 as isize);
                 ti2 = *cc.offset(t4 as isize) + *cc.offset(t5 as isize);
                 *ch.offset((t6 - 1 as libc::c_int) as isize) =
-                    *wa1.offset((i - 2 as libc::c_int) as isize) * tr2 -
-                        *wa1.offset((i - 1 as libc::c_int) as isize) * ti2;
-                *ch.offset(t6 as isize) =
-                    *wa1.offset((i - 2 as libc::c_int) as isize) * ti2 +
-                        *wa1.offset((i - 1 as libc::c_int) as isize) * tr2;
+                    *wa1.offset((i - 2 as libc::c_int) as isize) * tr2
+                        - *wa1.offset((i - 1 as libc::c_int) as isize) * ti2;
+                *ch.offset(t6 as isize) = *wa1.offset((i - 2 as libc::c_int) as isize) * ti2
+                    + *wa1.offset((i - 1 as libc::c_int) as isize) * tr2;
                 i += 2 as libc::c_int
             }
             t1 += ido;
             t2 = t1 << 1 as libc::c_int;
             k += 1
         }
-        if ido % 2 as libc::c_int == 1 as libc::c_int { return }
+        if ido % 2 as libc::c_int == 1 as libc::c_int {
+            return;
+        }
     }
     t1 = ido - 1 as libc::c_int;
     t2 = ido - 1 as libc::c_int;
     k = 0 as libc::c_int;
     while k < l1 {
-        *ch.offset(t1 as isize) =
-            *cc.offset(t2 as isize) + *cc.offset(t2 as isize);
-        *ch.offset((t1 + t0) as isize) =
-            -(*cc.offset((t2 + 1 as libc::c_int) as isize) +
-                  *cc.offset((t2 + 1 as libc::c_int) as isize));
+        *ch.offset(t1 as isize) = *cc.offset(t2 as isize) + *cc.offset(t2 as isize);
+        *ch.offset((t1 + t0) as isize) = -(*cc.offset((t2 + 1 as libc::c_int) as isize)
+            + *cc.offset((t2 + 1 as libc::c_int) as isize));
         t1 += ido;
         t2 += ido << 1 as libc::c_int;
         k += 1
-    };
+    }
 }
-unsafe extern "C" fn dradb3(mut ido: libc::c_int, mut l1: libc::c_int,
-                            mut cc: *mut libc::c_float,
-                            mut ch: *mut libc::c_float,
-                            mut wa1: *mut libc::c_float,
-                            mut wa2: *mut libc::c_float) {
+unsafe extern "C" fn dradb3(
+    mut ido: libc::c_int,
+    mut l1: libc::c_int,
+    mut cc: *mut libc::c_float,
+    mut ch: *mut libc::c_float,
+    mut wa1: *mut libc::c_float,
+    mut wa2: *mut libc::c_float,
+) {
     static mut taur: libc::c_float = -0.5f32;
     static mut taui: libc::c_float = 0.8660254037844386f32;
     let mut i: libc::c_int = 0;
@@ -1080,9 +1109,8 @@ unsafe extern "C" fn dradb3(mut ido: libc::c_int, mut l1: libc::c_int,
     t5 = 0 as libc::c_int;
     k = 0 as libc::c_int;
     while k < l1 {
-        tr2 =
-            *cc.offset((t3 - 1 as libc::c_int) as isize) +
-                *cc.offset((t3 - 1 as libc::c_int) as isize);
+        tr2 = *cc.offset((t3 - 1 as libc::c_int) as isize)
+            + *cc.offset((t3 - 1 as libc::c_int) as isize);
         cr2 = *cc.offset(t5 as isize) + taur * tr2;
         *ch.offset(t1 as isize) = *cc.offset(t5 as isize) + tr2;
         ci3 = taui * (*cc.offset(t3 as isize) + *cc.offset(t3 as isize));
@@ -1093,7 +1121,9 @@ unsafe extern "C" fn dradb3(mut ido: libc::c_int, mut l1: libc::c_int,
         t5 += t4;
         k += 1
     }
-    if ido == 1 as libc::c_int { return }
+    if ido == 1 as libc::c_int {
+        return;
+    }
     t1 = 0 as libc::c_int;
     t3 = ido << 1 as libc::c_int;
     k = 0 as libc::c_int;
@@ -1112,48 +1142,47 @@ unsafe extern "C" fn dradb3(mut ido: libc::c_int, mut l1: libc::c_int,
             t8 += 2 as libc::c_int;
             t9 += 2 as libc::c_int;
             t10 += 2 as libc::c_int;
-            tr2 =
-                *cc.offset((t5 - 1 as libc::c_int) as isize) +
-                    *cc.offset((t6 - 1 as libc::c_int) as isize);
+            tr2 = *cc.offset((t5 - 1 as libc::c_int) as isize)
+                + *cc.offset((t6 - 1 as libc::c_int) as isize);
             cr2 = *cc.offset((t7 - 1 as libc::c_int) as isize) + taur * tr2;
             *ch.offset((t8 - 1 as libc::c_int) as isize) =
                 *cc.offset((t7 - 1 as libc::c_int) as isize) + tr2;
             ti2 = *cc.offset(t5 as isize) - *cc.offset(t6 as isize);
             ci2 = *cc.offset(t7 as isize) + taur * ti2;
             *ch.offset(t8 as isize) = *cc.offset(t7 as isize) + ti2;
-            cr3 =
-                taui *
-                    (*cc.offset((t5 - 1 as libc::c_int) as isize) -
-                         *cc.offset((t6 - 1 as libc::c_int) as isize));
+            cr3 = taui
+                * (*cc.offset((t5 - 1 as libc::c_int) as isize)
+                    - *cc.offset((t6 - 1 as libc::c_int) as isize));
             ci3 = taui * (*cc.offset(t5 as isize) + *cc.offset(t6 as isize));
             dr2 = cr2 - ci3;
             dr3 = cr2 + ci3;
             di2 = ci2 + cr3;
             di3 = ci2 - cr3;
             *ch.offset((t9 - 1 as libc::c_int) as isize) =
-                *wa1.offset((i - 2 as libc::c_int) as isize) * dr2 -
-                    *wa1.offset((i - 1 as libc::c_int) as isize) * di2;
-            *ch.offset(t9 as isize) =
-                *wa1.offset((i - 2 as libc::c_int) as isize) * di2 +
-                    *wa1.offset((i - 1 as libc::c_int) as isize) * dr2;
+                *wa1.offset((i - 2 as libc::c_int) as isize) * dr2
+                    - *wa1.offset((i - 1 as libc::c_int) as isize) * di2;
+            *ch.offset(t9 as isize) = *wa1.offset((i - 2 as libc::c_int) as isize) * di2
+                + *wa1.offset((i - 1 as libc::c_int) as isize) * dr2;
             *ch.offset((t10 - 1 as libc::c_int) as isize) =
-                *wa2.offset((i - 2 as libc::c_int) as isize) * dr3 -
-                    *wa2.offset((i - 1 as libc::c_int) as isize) * di3;
-            *ch.offset(t10 as isize) =
-                *wa2.offset((i - 2 as libc::c_int) as isize) * di3 +
-                    *wa2.offset((i - 1 as libc::c_int) as isize) * dr3;
+                *wa2.offset((i - 2 as libc::c_int) as isize) * dr3
+                    - *wa2.offset((i - 1 as libc::c_int) as isize) * di3;
+            *ch.offset(t10 as isize) = *wa2.offset((i - 2 as libc::c_int) as isize) * di3
+                + *wa2.offset((i - 1 as libc::c_int) as isize) * dr3;
             i += 2 as libc::c_int
         }
         t1 += ido;
         k += 1
-    };
+    }
 }
-unsafe extern "C" fn dradb4(mut ido: libc::c_int, mut l1: libc::c_int,
-                            mut cc: *mut libc::c_float,
-                            mut ch: *mut libc::c_float,
-                            mut wa1: *mut libc::c_float,
-                            mut wa2: *mut libc::c_float,
-                            mut wa3: *mut libc::c_float) {
+unsafe extern "C" fn dradb4(
+    mut ido: libc::c_int,
+    mut l1: libc::c_int,
+    mut cc: *mut libc::c_float,
+    mut ch: *mut libc::c_float,
+    mut wa1: *mut libc::c_float,
+    mut wa2: *mut libc::c_float,
+    mut wa3: *mut libc::c_float,
+) {
     static mut sqrt2: libc::c_float = 1.414213562373095f32;
     let mut i: libc::c_int = 0;
     let mut k: libc::c_int = 0;
@@ -1189,17 +1218,12 @@ unsafe extern "C" fn dradb4(mut ido: libc::c_int, mut l1: libc::c_int,
     while k < l1 {
         t4 = t3 + t6;
         t5 = t1;
-        tr3 =
-            *cc.offset((t4 - 1 as libc::c_int) as isize) +
-                *cc.offset((t4 - 1 as libc::c_int) as isize);
+        tr3 = *cc.offset((t4 - 1 as libc::c_int) as isize)
+            + *cc.offset((t4 - 1 as libc::c_int) as isize);
         tr4 = *cc.offset(t4 as isize) + *cc.offset(t4 as isize);
         t4 += t6;
-        tr1 =
-            *cc.offset(t3 as isize) -
-                *cc.offset((t4 - 1 as libc::c_int) as isize);
-        tr2 =
-            *cc.offset(t3 as isize) +
-                *cc.offset((t4 - 1 as libc::c_int) as isize);
+        tr1 = *cc.offset(t3 as isize) - *cc.offset((t4 - 1 as libc::c_int) as isize);
+        tr2 = *cc.offset(t3 as isize) + *cc.offset((t4 - 1 as libc::c_int) as isize);
         *ch.offset(t5 as isize) = tr2 + tr3;
         t5 += t0;
         *ch.offset(t5 as isize) = tr1 - tr4;
@@ -1211,7 +1235,9 @@ unsafe extern "C" fn dradb4(mut ido: libc::c_int, mut l1: libc::c_int,
         t3 += t2;
         k += 1
     }
-    if ido < 2 as libc::c_int { return }
+    if ido < 2 as libc::c_int {
+        return;
+    }
     if !(ido == 2 as libc::c_int) {
         t1 = 0 as libc::c_int;
         k = 0 as libc::c_int;
@@ -1232,18 +1258,14 @@ unsafe extern "C" fn dradb4(mut ido: libc::c_int, mut l1: libc::c_int,
                 ti2 = *cc.offset(t2 as isize) - *cc.offset(t5 as isize);
                 ti3 = *cc.offset(t3 as isize) - *cc.offset(t4 as isize);
                 tr4 = *cc.offset(t3 as isize) + *cc.offset(t4 as isize);
-                tr1 =
-                    *cc.offset((t2 - 1 as libc::c_int) as isize) -
-                        *cc.offset((t5 - 1 as libc::c_int) as isize);
-                tr2 =
-                    *cc.offset((t2 - 1 as libc::c_int) as isize) +
-                        *cc.offset((t5 - 1 as libc::c_int) as isize);
-                ti4 =
-                    *cc.offset((t3 - 1 as libc::c_int) as isize) -
-                        *cc.offset((t4 - 1 as libc::c_int) as isize);
-                tr3 =
-                    *cc.offset((t3 - 1 as libc::c_int) as isize) +
-                        *cc.offset((t4 - 1 as libc::c_int) as isize);
+                tr1 = *cc.offset((t2 - 1 as libc::c_int) as isize)
+                    - *cc.offset((t5 - 1 as libc::c_int) as isize);
+                tr2 = *cc.offset((t2 - 1 as libc::c_int) as isize)
+                    + *cc.offset((t5 - 1 as libc::c_int) as isize);
+                ti4 = *cc.offset((t3 - 1 as libc::c_int) as isize)
+                    - *cc.offset((t4 - 1 as libc::c_int) as isize);
+                tr3 = *cc.offset((t3 - 1 as libc::c_int) as isize)
+                    + *cc.offset((t4 - 1 as libc::c_int) as isize);
                 *ch.offset((t7 - 1 as libc::c_int) as isize) = tr2 + tr3;
                 cr3 = tr2 - tr3;
                 *ch.offset(t7 as isize) = ti2 + ti3;
@@ -1254,31 +1276,30 @@ unsafe extern "C" fn dradb4(mut ido: libc::c_int, mut l1: libc::c_int,
                 ci4 = ti1 - ti4;
                 t8 = t7 + t0;
                 *ch.offset((t8 - 1 as libc::c_int) as isize) =
-                    *wa1.offset((i - 2 as libc::c_int) as isize) * cr2 -
-                        *wa1.offset((i - 1 as libc::c_int) as isize) * ci2;
-                *ch.offset(t8 as isize) =
-                    *wa1.offset((i - 2 as libc::c_int) as isize) * ci2 +
-                        *wa1.offset((i - 1 as libc::c_int) as isize) * cr2;
+                    *wa1.offset((i - 2 as libc::c_int) as isize) * cr2
+                        - *wa1.offset((i - 1 as libc::c_int) as isize) * ci2;
+                *ch.offset(t8 as isize) = *wa1.offset((i - 2 as libc::c_int) as isize) * ci2
+                    + *wa1.offset((i - 1 as libc::c_int) as isize) * cr2;
                 t8 += t0;
                 *ch.offset((t8 - 1 as libc::c_int) as isize) =
-                    *wa2.offset((i - 2 as libc::c_int) as isize) * cr3 -
-                        *wa2.offset((i - 1 as libc::c_int) as isize) * ci3;
-                *ch.offset(t8 as isize) =
-                    *wa2.offset((i - 2 as libc::c_int) as isize) * ci3 +
-                        *wa2.offset((i - 1 as libc::c_int) as isize) * cr3;
+                    *wa2.offset((i - 2 as libc::c_int) as isize) * cr3
+                        - *wa2.offset((i - 1 as libc::c_int) as isize) * ci3;
+                *ch.offset(t8 as isize) = *wa2.offset((i - 2 as libc::c_int) as isize) * ci3
+                    + *wa2.offset((i - 1 as libc::c_int) as isize) * cr3;
                 t8 += t0;
                 *ch.offset((t8 - 1 as libc::c_int) as isize) =
-                    *wa3.offset((i - 2 as libc::c_int) as isize) * cr4 -
-                        *wa3.offset((i - 1 as libc::c_int) as isize) * ci4;
-                *ch.offset(t8 as isize) =
-                    *wa3.offset((i - 2 as libc::c_int) as isize) * ci4 +
-                        *wa3.offset((i - 1 as libc::c_int) as isize) * cr4;
+                    *wa3.offset((i - 2 as libc::c_int) as isize) * cr4
+                        - *wa3.offset((i - 1 as libc::c_int) as isize) * ci4;
+                *ch.offset(t8 as isize) = *wa3.offset((i - 2 as libc::c_int) as isize) * ci4
+                    + *wa3.offset((i - 1 as libc::c_int) as isize) * cr4;
                 i += 2 as libc::c_int
             }
             t1 += ido;
             k += 1
         }
-        if ido % 2 as libc::c_int == 1 as libc::c_int { return }
+        if ido % 2 as libc::c_int == 1 as libc::c_int {
+            return;
+        }
     }
     t1 = ido;
     t2 = ido << 2 as libc::c_int;
@@ -1289,12 +1310,10 @@ unsafe extern "C" fn dradb4(mut ido: libc::c_int, mut l1: libc::c_int,
         t5 = t3;
         ti1 = *cc.offset(t1 as isize) + *cc.offset(t4 as isize);
         ti2 = *cc.offset(t4 as isize) - *cc.offset(t1 as isize);
-        tr1 =
-            *cc.offset((t1 - 1 as libc::c_int) as isize) -
-                *cc.offset((t4 - 1 as libc::c_int) as isize);
-        tr2 =
-            *cc.offset((t1 - 1 as libc::c_int) as isize) +
-                *cc.offset((t4 - 1 as libc::c_int) as isize);
+        tr1 = *cc.offset((t1 - 1 as libc::c_int) as isize)
+            - *cc.offset((t4 - 1 as libc::c_int) as isize);
+        tr2 = *cc.offset((t1 - 1 as libc::c_int) as isize)
+            + *cc.offset((t4 - 1 as libc::c_int) as isize);
         *ch.offset(t5 as isize) = tr2 + tr2;
         t5 += t0;
         *ch.offset(t5 as isize) = sqrt2 * (tr1 - ti1);
@@ -1306,16 +1325,20 @@ unsafe extern "C" fn dradb4(mut ido: libc::c_int, mut l1: libc::c_int,
         t1 += t2;
         t4 += t2;
         k += 1
-    };
+    }
 }
-unsafe extern "C" fn dradbg(mut ido: libc::c_int, mut ip: libc::c_int,
-                            mut l1: libc::c_int, mut idl1: libc::c_int,
-                            mut cc: *mut libc::c_float,
-                            mut c1: *mut libc::c_float,
-                            mut c2: *mut libc::c_float,
-                            mut ch: *mut libc::c_float,
-                            mut ch2: *mut libc::c_float,
-                            mut wa: *mut libc::c_float) {
+unsafe extern "C" fn dradbg(
+    mut ido: libc::c_int,
+    mut ip: libc::c_int,
+    mut l1: libc::c_int,
+    mut idl1: libc::c_int,
+    mut cc: *mut libc::c_float,
+    mut c1: *mut libc::c_float,
+    mut c2: *mut libc::c_float,
+    mut ch: *mut libc::c_float,
+    mut ch2: *mut libc::c_float,
+    mut wa: *mut libc::c_float,
+) {
     static mut tpi: libc::c_float = 6.283185307179586f32;
     let mut idij: libc::c_int = 0;
     let mut ipph: libc::c_int = 0;
@@ -1407,11 +1430,9 @@ unsafe extern "C" fn dradbg(mut ido: libc::c_int, mut ip: libc::c_int,
         t6 = t5;
         k = 0 as libc::c_int;
         while k < l1 {
-            *ch.offset(t3 as isize) =
-                *cc.offset((t6 - 1 as libc::c_int) as isize) +
-                    *cc.offset((t6 - 1 as libc::c_int) as isize);
-            *ch.offset(t4 as isize) =
-                *cc.offset(t6 as isize) + *cc.offset(t6 as isize);
+            *ch.offset(t3 as isize) = *cc.offset((t6 - 1 as libc::c_int) as isize)
+                + *cc.offset((t6 - 1 as libc::c_int) as isize);
+            *ch.offset(t4 as isize) = *cc.offset(t6 as isize) + *cc.offset(t6 as isize);
             t3 += ido;
             t4 += ido;
             t6 += t10;
@@ -1446,18 +1467,16 @@ unsafe extern "C" fn dradbg(mut ido: libc::c_int, mut ip: libc::c_int,
                     t12 = t9;
                     k = 0 as libc::c_int;
                     while k < l1 {
-                        *ch.offset((t5 - 1 as libc::c_int) as isize) =
-                            *cc.offset((t11 - 1 as libc::c_int) as isize) +
-                                *cc.offset((t12 - 1 as libc::c_int) as isize);
-                        *ch.offset((t6 - 1 as libc::c_int) as isize) =
-                            *cc.offset((t11 - 1 as libc::c_int) as isize) -
-                                *cc.offset((t12 - 1 as libc::c_int) as isize);
+                        *ch.offset((t5 - 1 as libc::c_int) as isize) = *cc
+                            .offset((t11 - 1 as libc::c_int) as isize)
+                            + *cc.offset((t12 - 1 as libc::c_int) as isize);
+                        *ch.offset((t6 - 1 as libc::c_int) as isize) = *cc
+                            .offset((t11 - 1 as libc::c_int) as isize)
+                            - *cc.offset((t12 - 1 as libc::c_int) as isize);
                         *ch.offset(t5 as isize) =
-                            *cc.offset(t11 as isize) -
-                                *cc.offset(t12 as isize);
+                            *cc.offset(t11 as isize) - *cc.offset(t12 as isize);
                         *ch.offset(t6 as isize) =
-                            *cc.offset(t11 as isize) +
-                                *cc.offset(t12 as isize);
+                            *cc.offset(t11 as isize) + *cc.offset(t12 as isize);
                         t5 += ido;
                         t6 += ido;
                         t11 += t10;
@@ -1492,18 +1511,16 @@ unsafe extern "C" fn dradbg(mut ido: libc::c_int, mut ip: libc::c_int,
                         t6 += 2 as libc::c_int;
                         t9 += 2 as libc::c_int;
                         t11 -= 2 as libc::c_int;
-                        *ch.offset((t5 - 1 as libc::c_int) as isize) =
-                            *cc.offset((t9 - 1 as libc::c_int) as isize) +
-                                *cc.offset((t11 - 1 as libc::c_int) as isize);
-                        *ch.offset((t6 - 1 as libc::c_int) as isize) =
-                            *cc.offset((t9 - 1 as libc::c_int) as isize) -
-                                *cc.offset((t11 - 1 as libc::c_int) as isize);
+                        *ch.offset((t5 - 1 as libc::c_int) as isize) = *cc
+                            .offset((t9 - 1 as libc::c_int) as isize)
+                            + *cc.offset((t11 - 1 as libc::c_int) as isize);
+                        *ch.offset((t6 - 1 as libc::c_int) as isize) = *cc
+                            .offset((t9 - 1 as libc::c_int) as isize)
+                            - *cc.offset((t11 - 1 as libc::c_int) as isize);
                         *ch.offset(t5 as isize) =
-                            *cc.offset(t9 as isize) -
-                                *cc.offset(t11 as isize);
+                            *cc.offset(t9 as isize) - *cc.offset(t11 as isize);
                         *ch.offset(t6 as isize) =
-                            *cc.offset(t9 as isize) +
-                                *cc.offset(t11 as isize);
+                            *cc.offset(t9 as isize) + *cc.offset(t11 as isize);
                         i += 2 as libc::c_int
                     }
                     t3 += ido;
@@ -1542,14 +1559,12 @@ unsafe extern "C" fn dradbg(mut ido: libc::c_int, mut ip: libc::c_int,
             let fresh15 = t4;
             t4 = t4 + 1;
             *c2.offset(fresh15 as isize) =
-                *ch2.offset(fresh13 as isize) +
-                    ar1 * *ch2.offset(fresh14 as isize);
+                *ch2.offset(fresh13 as isize) + ar1 * *ch2.offset(fresh14 as isize);
             let fresh16 = t8;
             t8 = t8 + 1;
             let fresh17 = t5;
             t5 = t5 + 1;
-            *c2.offset(fresh17 as isize) =
-                ai1 * *ch2.offset(fresh16 as isize);
+            *c2.offset(fresh17 as isize) = ai1 * *ch2.offset(fresh16 as isize);
             ik += 1
         }
         dc2 = ar1;
@@ -1575,14 +1590,12 @@ unsafe extern "C" fn dradbg(mut ido: libc::c_int, mut ip: libc::c_int,
                 t11 = t11 + 1;
                 let fresh19 = t4;
                 t4 = t4 + 1;
-                *c2.offset(fresh19 as isize) +=
-                    ar2 * *ch2.offset(fresh18 as isize);
+                *c2.offset(fresh19 as isize) += ar2 * *ch2.offset(fresh18 as isize);
                 let fresh20 = t12;
                 t12 = t12 + 1;
                 let fresh21 = t5;
                 t5 = t5 + 1;
-                *c2.offset(fresh21 as isize) +=
-                    ai2 * *ch2.offset(fresh20 as isize);
+                *c2.offset(fresh21 as isize) += ai2 * *ch2.offset(fresh20 as isize);
                 ik += 1
             }
             j += 1
@@ -1613,10 +1626,8 @@ unsafe extern "C" fn dradbg(mut ido: libc::c_int, mut ip: libc::c_int,
         t4 = t2;
         k = 0 as libc::c_int;
         while k < l1 {
-            *ch.offset(t3 as isize) =
-                *c1.offset(t3 as isize) - *c1.offset(t4 as isize);
-            *ch.offset(t4 as isize) =
-                *c1.offset(t3 as isize) + *c1.offset(t4 as isize);
+            *ch.offset(t3 as isize) = *c1.offset(t3 as isize) - *c1.offset(t4 as isize);
+            *ch.offset(t4 as isize) = *c1.offset(t3 as isize) + *c1.offset(t4 as isize);
             t3 += ido;
             t4 += ido;
             k += 1
@@ -1642,17 +1653,13 @@ unsafe extern "C" fn dradbg(mut ido: libc::c_int, mut ip: libc::c_int,
                     k = 0 as libc::c_int;
                     while k < l1 {
                         *ch.offset((t5 - 1 as libc::c_int) as isize) =
-                            *c1.offset((t5 - 1 as libc::c_int) as isize) -
-                                *c1.offset(t6 as isize);
+                            *c1.offset((t5 - 1 as libc::c_int) as isize) - *c1.offset(t6 as isize);
                         *ch.offset((t6 - 1 as libc::c_int) as isize) =
-                            *c1.offset((t5 - 1 as libc::c_int) as isize) +
-                                *c1.offset(t6 as isize);
+                            *c1.offset((t5 - 1 as libc::c_int) as isize) + *c1.offset(t6 as isize);
                         *ch.offset(t5 as isize) =
-                            *c1.offset(t5 as isize) +
-                                *c1.offset((t6 - 1 as libc::c_int) as isize);
+                            *c1.offset(t5 as isize) + *c1.offset((t6 - 1 as libc::c_int) as isize);
                         *ch.offset(t6 as isize) =
-                            *c1.offset(t5 as isize) -
-                                *c1.offset((t6 - 1 as libc::c_int) as isize);
+                            *c1.offset(t5 as isize) - *c1.offset((t6 - 1 as libc::c_int) as isize);
                         t5 += ido;
                         t6 += ido;
                         k += 1
@@ -1679,17 +1686,13 @@ unsafe extern "C" fn dradbg(mut ido: libc::c_int, mut ip: libc::c_int,
                         t5 += 2 as libc::c_int;
                         t6 += 2 as libc::c_int;
                         *ch.offset((t5 - 1 as libc::c_int) as isize) =
-                            *c1.offset((t5 - 1 as libc::c_int) as isize) -
-                                *c1.offset(t6 as isize);
+                            *c1.offset((t5 - 1 as libc::c_int) as isize) - *c1.offset(t6 as isize);
                         *ch.offset((t6 - 1 as libc::c_int) as isize) =
-                            *c1.offset((t5 - 1 as libc::c_int) as isize) +
-                                *c1.offset(t6 as isize);
+                            *c1.offset((t5 - 1 as libc::c_int) as isize) + *c1.offset(t6 as isize);
                         *ch.offset(t5 as isize) =
-                            *c1.offset(t5 as isize) +
-                                *c1.offset((t6 - 1 as libc::c_int) as isize);
+                            *c1.offset(t5 as isize) + *c1.offset((t6 - 1 as libc::c_int) as isize);
                         *ch.offset(t6 as isize) =
-                            *c1.offset(t5 as isize) -
-                                *c1.offset((t6 - 1 as libc::c_int) as isize);
+                            *c1.offset(t5 as isize) - *c1.offset((t6 - 1 as libc::c_int) as isize);
                         i += 2 as libc::c_int
                     }
                     t3 += ido;
@@ -1700,7 +1703,9 @@ unsafe extern "C" fn dradbg(mut ido: libc::c_int, mut ip: libc::c_int,
             }
         }
     }
-    if ido == 1 as libc::c_int { return }
+    if ido == 1 as libc::c_int {
+        return;
+    }
     ik = 0 as libc::c_int;
     while ik < idl1 {
         *c2.offset(ik as isize) = *ch2.offset(ik as isize);
@@ -1735,16 +1740,13 @@ unsafe extern "C" fn dradbg(mut ido: libc::c_int, mut ip: libc::c_int,
                 while i < ido {
                     idij += 2 as libc::c_int;
                     t3 += 2 as libc::c_int;
-                    *c1.offset((t3 - 1 as libc::c_int) as isize) =
-                        *wa.offset((idij - 1 as libc::c_int) as isize) *
-                            *ch.offset((t3 - 1 as libc::c_int) as isize) -
-                            *wa.offset(idij as isize) *
-                                *ch.offset(t3 as isize);
-                    *c1.offset(t3 as isize) =
-                        *wa.offset((idij - 1 as libc::c_int) as isize) *
-                            *ch.offset(t3 as isize) +
-                            *wa.offset(idij as isize) *
-                                *ch.offset((t3 - 1 as libc::c_int) as isize);
+                    *c1.offset((t3 - 1 as libc::c_int) as isize) = *wa
+                        .offset((idij - 1 as libc::c_int) as isize)
+                        * *ch.offset((t3 - 1 as libc::c_int) as isize)
+                        - *wa.offset(idij as isize) * *ch.offset(t3 as isize);
+                    *c1.offset(t3 as isize) = *wa.offset((idij - 1 as libc::c_int) as isize)
+                        * *ch.offset(t3 as isize)
+                        + *wa.offset(idij as isize) * *ch.offset((t3 - 1 as libc::c_int) as isize);
                     i += 2 as libc::c_int
                 }
                 t2 += ido;
@@ -1769,16 +1771,13 @@ unsafe extern "C" fn dradbg(mut ido: libc::c_int, mut ip: libc::c_int,
                 t3 = t2;
                 k = 0 as libc::c_int;
                 while k < l1 {
-                    *c1.offset((t3 - 1 as libc::c_int) as isize) =
-                        *wa.offset((idij - 1 as libc::c_int) as isize) *
-                            *ch.offset((t3 - 1 as libc::c_int) as isize) -
-                            *wa.offset(idij as isize) *
-                                *ch.offset(t3 as isize);
-                    *c1.offset(t3 as isize) =
-                        *wa.offset((idij - 1 as libc::c_int) as isize) *
-                            *ch.offset(t3 as isize) +
-                            *wa.offset(idij as isize) *
-                                *ch.offset((t3 - 1 as libc::c_int) as isize);
+                    *c1.offset((t3 - 1 as libc::c_int) as isize) = *wa
+                        .offset((idij - 1 as libc::c_int) as isize)
+                        * *ch.offset((t3 - 1 as libc::c_int) as isize)
+                        - *wa.offset(idij as isize) * *ch.offset(t3 as isize);
+                    *c1.offset(t3 as isize) = *wa.offset((idij - 1 as libc::c_int) as isize)
+                        * *ch.offset(t3 as isize)
+                        + *wa.offset(idij as isize) * *ch.offset((t3 - 1 as libc::c_int) as isize);
                     t3 += ido;
                     k += 1
                 }
@@ -1786,13 +1785,16 @@ unsafe extern "C" fn dradbg(mut ido: libc::c_int, mut ip: libc::c_int,
             }
             j += 1
         }
-        return
+        return;
     };
 }
-unsafe extern "C" fn drftb1(mut n: libc::c_int, mut c: *mut libc::c_float,
-                            mut ch: *mut libc::c_float,
-                            mut wa: *mut libc::c_float,
-                            mut ifac: *mut libc::c_int) {
+unsafe extern "C" fn drftb1(
+    mut n: libc::c_int,
+    mut c: *mut libc::c_float,
+    mut ch: *mut libc::c_float,
+    mut wa: *mut libc::c_float,
+    mut ifac: *mut libc::c_int,
+) {
     let mut i: libc::c_int = 0;
     let mut k1: libc::c_int = 0;
     let mut l1: libc::c_int = 0;
@@ -1819,63 +1821,89 @@ unsafe extern "C" fn drftb1(mut n: libc::c_int, mut c: *mut libc::c_float,
             if ip != 2 as libc::c_int {
                 if ip != 3 as libc::c_int {
                     /*    The radix five case can be translated later..... */
-/*    if(ip!=5)goto L112;
+                    /*    if(ip!=5)goto L112;
 
-    ix2=iw+ido;
-    ix3=ix2+ido;
-    ix4=ix3+ido;
-    if(na!=0)
-      dradb5(ido,l1,ch,c,wa+iw-1,wa+ix2-1,wa+ix3-1,wa+ix4-1);
-    else
-      dradb5(ido,l1,c,ch,wa+iw-1,wa+ix2-1,wa+ix3-1,wa+ix4-1);
-    na=1-na;
-    goto L115;
+                      ix2=iw+ido;
+                      ix3=ix2+ido;
+                      ix4=ix3+ido;
+                      if(na!=0)
+                        dradb5(ido,l1,ch,c,wa+iw-1,wa+ix2-1,wa+ix3-1,wa+ix4-1);
+                      else
+                        dradb5(ido,l1,c,ch,wa+iw-1,wa+ix2-1,wa+ix3-1,wa+ix4-1);
+                      na=1-na;
+                      goto L115;
 
-  L112:*/
+                    L112:*/
                     if na != 0 as libc::c_int {
-                        dradbg(ido, ip, l1, idl1, ch, ch, ch, c, c,
-                               wa.offset(iw as
-                                             isize).offset(-(1 as libc::c_int
-                                                                 as isize)));
+                        dradbg(
+                            ido,
+                            ip,
+                            l1,
+                            idl1,
+                            ch,
+                            ch,
+                            ch,
+                            c,
+                            c,
+                            wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
+                        );
                     } else {
-                        dradbg(ido, ip, l1, idl1, c, c, c, ch, ch,
-                               wa.offset(iw as
-                                             isize).offset(-(1 as libc::c_int
-                                                                 as isize)));
+                        dradbg(
+                            ido,
+                            ip,
+                            l1,
+                            idl1,
+                            c,
+                            c,
+                            c,
+                            ch,
+                            ch,
+                            wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
+                        );
                     }
-                    if ido == 1 as libc::c_int { na = 1 as libc::c_int - na }
+                    if ido == 1 as libc::c_int {
+                        na = 1 as libc::c_int - na
+                    }
                 } else {
                     ix2 = iw + ido;
                     if na != 0 as libc::c_int {
-                        dradb3(ido, l1, ch, c,
-                               wa.offset(iw as
-                                             isize).offset(-(1 as libc::c_int
-                                                                 as isize)),
-                               wa.offset(ix2 as
-                                             isize).offset(-(1 as libc::c_int
-                                                                 as isize)));
+                        dradb3(
+                            ido,
+                            l1,
+                            ch,
+                            c,
+                            wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
+                            wa.offset(ix2 as isize).offset(-(1 as libc::c_int as isize)),
+                        );
                     } else {
-                        dradb3(ido, l1, c, ch,
-                               wa.offset(iw as
-                                             isize).offset(-(1 as libc::c_int
-                                                                 as isize)),
-                               wa.offset(ix2 as
-                                             isize).offset(-(1 as libc::c_int
-                                                                 as isize)));
+                        dradb3(
+                            ido,
+                            l1,
+                            c,
+                            ch,
+                            wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
+                            wa.offset(ix2 as isize).offset(-(1 as libc::c_int as isize)),
+                        );
                     }
                     na = 1 as libc::c_int - na
                 }
             } else {
                 if na != 0 as libc::c_int {
-                    dradb2(ido, l1, ch, c,
-                           wa.offset(iw as
-                                         isize).offset(-(1 as libc::c_int as
-                                                             isize)));
+                    dradb2(
+                        ido,
+                        l1,
+                        ch,
+                        c,
+                        wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
+                    );
                 } else {
-                    dradb2(ido, l1, c, ch,
-                           wa.offset(iw as
-                                         isize).offset(-(1 as libc::c_int as
-                                                             isize)));
+                    dradb2(
+                        ido,
+                        l1,
+                        c,
+                        ch,
+                        wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
+                    );
                 }
                 na = 1 as libc::c_int - na
             }
@@ -1883,27 +1911,25 @@ unsafe extern "C" fn drftb1(mut n: libc::c_int, mut c: *mut libc::c_float,
             ix2 = iw + ido;
             ix3 = ix2 + ido;
             if na != 0 as libc::c_int {
-                dradb4(ido, l1, ch, c,
-                       wa.offset(iw as
-                                     isize).offset(-(1 as libc::c_int as
-                                                         isize)),
-                       wa.offset(ix2 as
-                                     isize).offset(-(1 as libc::c_int as
-                                                         isize)),
-                       wa.offset(ix3 as
-                                     isize).offset(-(1 as libc::c_int as
-                                                         isize)));
+                dradb4(
+                    ido,
+                    l1,
+                    ch,
+                    c,
+                    wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
+                    wa.offset(ix2 as isize).offset(-(1 as libc::c_int as isize)),
+                    wa.offset(ix3 as isize).offset(-(1 as libc::c_int as isize)),
+                );
             } else {
-                dradb4(ido, l1, c, ch,
-                       wa.offset(iw as
-                                     isize).offset(-(1 as libc::c_int as
-                                                         isize)),
-                       wa.offset(ix2 as
-                                     isize).offset(-(1 as libc::c_int as
-                                                         isize)),
-                       wa.offset(ix3 as
-                                     isize).offset(-(1 as libc::c_int as
-                                                         isize)));
+                dradb4(
+                    ido,
+                    l1,
+                    c,
+                    ch,
+                    wa.offset(iw as isize).offset(-(1 as libc::c_int as isize)),
+                    wa.offset(ix2 as isize).offset(-(1 as libc::c_int as isize)),
+                    wa.offset(ix3 as isize).offset(-(1 as libc::c_int as isize)),
+                );
             }
             na = 1 as libc::c_int - na
         }
@@ -1911,38 +1937,54 @@ unsafe extern "C" fn drftb1(mut n: libc::c_int, mut c: *mut libc::c_float,
         iw += (ip - 1 as libc::c_int) * ido;
         k1 += 1
     }
-    if na == 0 as libc::c_int { return }
+    if na == 0 as libc::c_int {
+        return;
+    }
     i = 0 as libc::c_int;
-    while i < n { *c.offset(i as isize) = *ch.offset(i as isize); i += 1 };
+    while i < n {
+        *c.offset(i as isize) = *ch.offset(i as isize);
+        i += 1
+    }
 }
 #[no_mangle]
-pub unsafe extern "C" fn spx_drft_forward(mut l: *mut drft_lookup,
-                                          mut data: *mut libc::c_float) {
-    if (*l).n == 1 as libc::c_int { return }
-    drftf1((*l).n, data, (*l).trigcache,
-           (*l).trigcache.offset((*l).n as isize), (*l).splitcache);
+pub unsafe extern "C" fn spx_drft_forward(mut l: *mut drft_lookup, mut data: *mut libc::c_float) {
+    if (*l).n == 1 as libc::c_int {
+        return;
+    }
+    drftf1(
+        (*l).n,
+        data,
+        (*l).trigcache,
+        (*l).trigcache.offset((*l).n as isize),
+        (*l).splitcache,
+    );
 }
 #[no_mangle]
-pub unsafe extern "C" fn spx_drft_backward(mut l: *mut drft_lookup,
-                                           mut data: *mut libc::c_float) {
-    if (*l).n == 1 as libc::c_int { return }
-    drftb1((*l).n, data, (*l).trigcache,
-           (*l).trigcache.offset((*l).n as isize), (*l).splitcache);
+pub unsafe extern "C" fn spx_drft_backward(mut l: *mut drft_lookup, mut data: *mut libc::c_float) {
+    if (*l).n == 1 as libc::c_int {
+        return;
+    }
+    drftb1(
+        (*l).n,
+        data,
+        (*l).trigcache,
+        (*l).trigcache.offset((*l).n as isize),
+        (*l).splitcache,
+    );
 }
 #[no_mangle]
-pub unsafe extern "C" fn spx_drft_init(mut l: *mut drft_lookup,
-                                       mut n: libc::c_int) {
+pub unsafe extern "C" fn spx_drft_init(mut l: *mut drft_lookup, mut n: libc::c_int) {
     (*l).n = n;
-    (*l).trigcache =
-        speex_alloc(((3 as libc::c_int * n) as
-                         libc::c_ulong).wrapping_mul(::std::mem::size_of::<libc::c_float>()
-                                                         as libc::c_ulong) as
-                        libc::c_int) as *mut libc::c_float;
-    (*l).splitcache =
-        speex_alloc((32 as libc::c_int as
-                         libc::c_ulong).wrapping_mul(::std::mem::size_of::<libc::c_int>()
-                                                         as libc::c_ulong) as
-                        libc::c_int) as *mut libc::c_int;
+    (*l).trigcache = speex_alloc(
+        ((3 as libc::c_int * n) as libc::c_ulong)
+            .wrapping_mul(::std::mem::size_of::<libc::c_float>() as libc::c_ulong)
+            as libc::c_int,
+    ) as *mut libc::c_float;
+    (*l).splitcache = speex_alloc(
+        (32 as libc::c_int as libc::c_ulong)
+            .wrapping_mul(::std::mem::size_of::<libc::c_int>() as libc::c_ulong)
+            as libc::c_int,
+    ) as *mut libc::c_int;
     fdrffti(n, (*l).trigcache, (*l).splitcache);
 }
 #[no_mangle]


### PR DESCRIPTION
Just replaced the `libc` types with the ones in `std`.

~~There is a high chance the crate won't link, because the external calls to `malloc`, `calloc`, `free` and `fprintf` are still present in the code. However, if `speexdfp` is used at link time, it should provide a transitive link to `libc`.~~ `libc` dependency has been left in `Cargo.toml`

Should partially solve the first point of https://github.com/rust-av/speexdsp-rs/issues/55