### PR TITLE
Removed unstable feature flags

### DIFF
--- a/fft/src/lib.rs
+++ b/fft/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(const_raw_ptr_to_usize_cast, extern_types, register_tool)]
-
 mod fftwrap;
 mod smallft;
 


### PR DESCRIPTION
It looks like everything works fine in stable Rust.

Small info: `cargo miri test` passes.