### PR TITLE
Use the right splitcache buffer size

### DIFF
--- a/fft/src/smallft.rs
+++ b/fft/src/smallft.rs
@@ -2130,7 +2130,7 @@ mod tests {
         const EPSILON: c_float = 1e-6;
 
         let mut trigcache = [0. as c_float; SIZE * 3];
-        let mut splitcache = [0 as c_int; SIZE * 32];
+        let mut splitcache = [0 as c_int; 32];
 
         unsafe {
             super::fdrffti(


### PR DESCRIPTION
Fixes issue [#61](https://github.com/rust-av/speexdsp-rs/issues/61)