### PR TITLE
Add rustfmt to github workflows

### DIFF
--- a/.github/workflows/speexdsp.yml
+++ b/.github/workflows/speexdsp.yml
@@ -3,6 +3,25 @@ name: speexdsp
 on: [push, pull_request]
 
 jobs:
+  rustfmt:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install stable
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+        components: rustfmt
+    - name: Run rustfmt
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: -- --check --verbose
+
   build:
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
At the current state, the new job fails. This is expected because the project is not perfectly formatted.