### PR TITLE
added criterion, benchmarking c vs rust resamplers on resampling example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ assert_approx_eq = "1.1.0"
 byteorder = "1.3"
 interpolate_name = "0.2.2"
 structopt = "0.3"
+criterion = "0.3"
 
 [dependencies]
 speexdsp-sys = { version = "0.1.1", path = "speexdsp-sys", optional = true }
@@ -26,3 +27,11 @@ speexdsp-resampler = { version = "0.1", path = "resampler" }
 
 [workspace]
 members = ["speexdsp-sys", "resampler", "fft"]
+
+[[bench]]
+name = "resampling_c"
+harness = false
+
+[[bench]]
+name = "resampling_rust"
+harness = false

--- a/benches/comparison.sh
+++ b/benches/comparison.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+
+set -e
+
+echo "Cloning speexdsp"
+git clone --depth 1  https://github.com/xiph/speexdsp target/speexdsp_repo || true
+cd target/speexdsp
+echo "Running ./autogen.sh from speexdsp repo"
+./autogen.sh
+echo "\nRunning ./configure with disabled sse from speexdsp repo\n"
+./configure --disable-sse --quiet
+echo "\nCompiling speexdsp\n"
+make -s
+export DSP_LIB=$(pwd)/libspeexdsp/.libs/libspeexdsp.so.1
+cd ../../
+echo "\nRunning resampler_c with LD_PRELOAD=${DSP_LIB}\n"
+LD_PRELOAD=$DSP_LIB cargo bench -q --features sys -- resampler_c
+echo "\nRunning resampler_rust\n"
+cargo bench -q -- resampler_rust

--- a/benches/resampling_c.rs
+++ b/benches/resampling_c.rs
@@ -1,0 +1,72 @@
+#[cfg(feature = "sys")]
+extern crate speexdsp_sys;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+#[cfg(feature = "sys")]
+use speexdsp_sys::resampler::*;
+
+#[cfg(feature = "sys")]
+fn resample_c() {
+    use std::f32::consts::PI;
+    use std::ptr;
+
+    const PERIOD: f32 = 32f32;
+    const INBLOCK: usize = 1024;
+    const RATE: u32 = 48000;
+
+    let mut rate = 1000;
+    let mut off = 0;
+    let mut avail = INBLOCK as isize;
+
+    let fin: Vec<f32> = (0..INBLOCK * 4)
+        .map(|i| ((i as f32) / PERIOD * 2.0 * PI).sin() * 0.9)
+        .collect();
+    let mut fout = vec![0f32; INBLOCK * 4];
+
+    let st =
+        unsafe { speex_resampler_init(1, RATE, RATE, 8, ptr::null_mut()) };
+    unsafe { speex_resampler_set_rate(st, RATE, rate) };
+    unsafe { speex_resampler_skip_zeros(st) };
+
+    loop {
+        let mut in_len = avail as u32;
+        let mut out_len = (in_len * rate + RATE - 1) / RATE;
+
+        unsafe {
+            speex_resampler_process_float(
+                st,
+                0,
+                fin[off..].as_ptr(),
+                &mut in_len,
+                fout.as_mut_ptr(),
+                &mut out_len,
+            )
+        };
+
+        off += in_len as usize;
+        avail += INBLOCK as isize - in_len as isize;
+
+        if off >= INBLOCK {
+            off -= INBLOCK;
+        }
+
+        rate += 5000;
+        if rate > 128000 {
+            break;
+        }
+
+        unsafe { speex_resampler_set_rate(st, RATE, rate) };
+    }
+
+    unsafe { speex_resampler_destroy(st) };
+}
+
+#[cfg(not(feature = "sys"))]
+fn resample_c() {}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("resampler_c", |b| b.iter(|| resample_c()));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/resampling_rust.rs
+++ b/benches/resampling_rust.rs
@@ -1,0 +1,58 @@
+use std::f32::consts::PI;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use speexdsp::resampler::*;
+
+const PERIOD: f32 = 32f32;
+const INBLOCK: usize = 1024;
+const RATE: usize = 48000;
+
+fn resample_rs() {
+    let mut rate = 1000;
+    let mut off = 0;
+    let mut avail = INBLOCK as isize;
+
+    let fin: Vec<f32> = (0..INBLOCK * 4)
+        .map(|i| ((i as f32) / PERIOD * 2.0 * PI).sin() * 0.9)
+        .collect();
+    let mut fout = vec![0f32; INBLOCK * 8];
+
+    let mut st = State::new(1, RATE, RATE, 8).unwrap();
+
+    st.set_rate(RATE, rate).unwrap();
+    st.skip_zeros();
+
+    let mut data = Vec::new();
+
+    loop {
+        let in_len = avail as usize;
+        let out_len = (in_len * rate + RATE - 1) / RATE;
+
+        let (in_len, out_len) = st
+            .process_float(0, &fin[off..off + in_len], &mut fout[..out_len])
+            .unwrap();
+
+        off += in_len as usize;
+        avail += INBLOCK as isize - in_len as isize;
+
+        if off >= INBLOCK {
+            off -= INBLOCK;
+        }
+
+        data.push(fout[..out_len as usize].to_vec());
+
+        rate += 5000;
+        if rate > 128000 {
+            break;
+        }
+
+        st.set_rate(RATE, rate).unwrap();
+    }
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("resampler_rust", |b| b.iter(|| resample_rs()));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
running the benchmark in this PR (that compares C and rust versions of resampler as suggested by #12) I get this results on intel `i7-6700K CPU @ 4.00GHz`:

```
Benchmarking speexdsp/rs/1: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 88.1s or reduce sample count to 10.
speexdsp/rs/1           time:   [18.109 ms 18.307 ms 18.533 ms]
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
Benchmarking speexdsp/c/2: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 14.0s or reduce sample count to 40.
speexdsp/c/2            time:   [2.7246 ms 2.7398 ms 2.7571 ms]
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
```

basically C version is ~9 times faster