### PR TITLE
added dynnative feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 sys = ["speexdsp-sys"]
 sse3 = [ "speexdsp-resampler/sse3" ]
 avx = [ "speexdsp-resampler/avx" ]
+dynnative = [ "speexdsp-resampler/dynnative" ]
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"

--- a/resampler/Cargo.toml
+++ b/resampler/Cargo.toml
@@ -12,7 +12,8 @@ edition = "2018"
 
 [features]
 sse3 = []
-avx = []
+avx = ["sse3"]
+dynnative = ["avx"]
 
 [dependencies]
 cfg-if = "0.1.10"

--- a/resampler/src/speex.rs
+++ b/resampler/src/speex.rs
@@ -833,7 +833,9 @@ fn resampler_basic_zero(
 }
 
 cfg_if! {
-    if #[cfg(feature = "avx")] {
+    if #[cfg(feature = "dynnative")] {
+        use dynnative::*;
+    } else if #[cfg(feature = "avx")] {
         use avx::*;
     } else if #[cfg(feature = "sse3")] {
         use sse3::*;
@@ -1286,7 +1288,8 @@ fn speex_resampler_magic<'a, 'b>(
 
 #[cfg(feature = "avx")]
 mod avx;
-#[cfg(not(any(feature = "sse3", feature = "avx")))]
+#[cfg(feature = "dynnative")]
+mod dynnative;
 mod native;
-#[cfg(any(feature = "sse3", feature = "avx"))]
+#[cfg(feature = "sse3")]
 mod sse3;

--- a/resampler/src/speex/dynnative/avx_wrapper.rs
+++ b/resampler/src/speex/dynnative/avx_wrapper.rs
@@ -1,0 +1,65 @@
+#[allow(clippy::too_many_arguments)]
+#[target_feature(enable = "avx")]
+pub unsafe fn interpolate_step_single(
+    in_slice: &[f32],
+    out_slice: &mut [f32],
+    out_stride: usize,
+    out_sample: usize,
+    oversample: usize,
+    offset: usize,
+    n: usize,
+    sinc_table: &[f32],
+    frac: f32,
+) {
+    crate::speex::avx::interpolate_step_single(
+        in_slice, out_slice, out_stride, out_sample, oversample, offset, n,
+        sinc_table, frac,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+#[target_feature(enable = "avx")]
+pub unsafe fn interpolate_step_double(
+    in_slice: &[f32],
+    out_slice: &mut [f32],
+    out_stride: usize,
+    out_sample: usize,
+    oversample: usize,
+    offset: usize,
+    n: usize,
+    sinc_table: &[f32],
+    frac: f32,
+) {
+    crate::speex::avx::interpolate_step_double(
+        in_slice, out_slice, out_stride, out_sample, oversample, offset, n,
+        sinc_table, frac,
+    );
+}
+
+#[target_feature(enable = "avx")]
+pub unsafe fn direct_step_single(
+    in_slice: &[f32],
+    out_slice: &mut [f32],
+    out_stride: usize,
+    out_sample: usize,
+    n: usize,
+    sinc_table: &[f32],
+) {
+    crate::speex::avx::direct_step_single(
+        in_slice, out_slice, out_stride, out_sample, n, sinc_table,
+    );
+}
+
+#[target_feature(enable = "avx")]
+pub unsafe fn direct_step_double(
+    in_slice: &[f32],
+    out_slice: &mut [f32],
+    out_stride: usize,
+    out_sample: usize,
+    n: usize,
+    sinc_table: &[f32],
+) {
+    crate::speex::avx::direct_step_double(
+        in_slice, out_slice, out_stride, out_sample, n, sinc_table,
+    );
+}

--- a/resampler/src/speex/dynnative/mod.rs
+++ b/resampler/src/speex/dynnative/mod.rs
@@ -1,0 +1,156 @@
+#[allow(clippy::too_many_arguments)]
+#[inline(always)]
+pub fn interpolate_step_single(
+    in_slice: &[f32],
+    out_slice: &mut [f32],
+    out_stride: usize,
+    out_sample: usize,
+    oversample: usize,
+    offset: usize,
+    n: usize,
+    sinc_table: &[f32],
+    frac: f32,
+) {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        if is_x86_feature_detected!("avx") {
+            unsafe {
+                avx_wrapper::interpolate_step_single(
+                    in_slice, out_slice, out_stride, out_sample, oversample,
+                    offset, n, sinc_table, frac,
+                );
+            }
+            return;
+        }
+
+        if is_x86_feature_detected!("sse3") {
+            unsafe {
+                sse3_wrapper::interpolate_step_single(
+                    in_slice, out_slice, out_stride, out_sample, oversample,
+                    offset, n, sinc_table, frac,
+                );
+            }
+            return;
+        }
+    }
+
+    super::native::interpolate_step_single(
+        in_slice, out_slice, out_stride, out_sample, oversample, offset, n,
+        sinc_table, frac,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+#[inline(always)]
+pub fn interpolate_step_double(
+    in_slice: &[f32],
+    out_slice: &mut [f32],
+    out_stride: usize,
+    out_sample: usize,
+    oversample: usize,
+    offset: usize,
+    n: usize,
+    sinc_table: &[f32],
+    frac: f32,
+) {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        if is_x86_feature_detected!("avx") {
+            unsafe {
+                avx_wrapper::interpolate_step_double(
+                    in_slice, out_slice, out_stride, out_sample, oversample,
+                    offset, n, sinc_table, frac,
+                );
+            }
+            return;
+        }
+
+        if is_x86_feature_detected!("sse3") {
+            unsafe {
+                sse3_wrapper::interpolate_step_double(
+                    in_slice, out_slice, out_stride, out_sample, oversample,
+                    offset, n, sinc_table, frac,
+                );
+            }
+            return;
+        }
+    }
+
+    super::native::interpolate_step_double(
+        in_slice, out_slice, out_stride, out_sample, oversample, offset, n,
+        sinc_table, frac,
+    );
+}
+
+#[inline(always)]
+pub fn direct_step_single(
+    in_slice: &[f32],
+    out_slice: &mut [f32],
+    out_stride: usize,
+    out_sample: usize,
+    n: usize,
+    sinc_table: &[f32],
+) {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        if is_x86_feature_detected!("avx") {
+            unsafe {
+                avx_wrapper::direct_step_single(
+                    in_slice, out_slice, out_stride, out_sample, n, sinc_table,
+                );
+            }
+            return;
+        }
+
+        if is_x86_feature_detected!("sse3") {
+            unsafe {
+                sse3_wrapper::direct_step_single(
+                    in_slice, out_slice, out_stride, out_sample, n, sinc_table,
+                );
+            }
+            return;
+        }
+    }
+
+    super::native::direct_step_single(
+        in_slice, out_slice, out_stride, out_sample, n, sinc_table,
+    );
+}
+
+#[inline(always)]
+pub fn direct_step_double(
+    in_slice: &[f32],
+    out_slice: &mut [f32],
+    out_stride: usize,
+    out_sample: usize,
+    n: usize,
+    sinc_table: &[f32],
+) {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        if is_x86_feature_detected!("avx") {
+            unsafe {
+                avx_wrapper::direct_step_double(
+                    in_slice, out_slice, out_stride, out_sample, n, sinc_table,
+                );
+            }
+            return;
+        }
+
+        if is_x86_feature_detected!("sse3") {
+            unsafe {
+                sse3_wrapper::direct_step_double(
+                    in_slice, out_slice, out_stride, out_sample, n, sinc_table,
+                );
+            }
+            return;
+        }
+    }
+
+    super::native::direct_step_double(
+        in_slice, out_slice, out_stride, out_sample, n, sinc_table,
+    );
+}
+
+mod avx_wrapper;
+mod sse3_wrapper;

--- a/resampler/src/speex/dynnative/sse3_wrapper.rs
+++ b/resampler/src/speex/dynnative/sse3_wrapper.rs
@@ -1,0 +1,65 @@
+#[allow(clippy::too_many_arguments)]
+#[target_feature(enable = "sse3")]
+pub unsafe fn interpolate_step_single(
+    in_slice: &[f32],
+    out_slice: &mut [f32],
+    out_stride: usize,
+    out_sample: usize,
+    oversample: usize,
+    offset: usize,
+    n: usize,
+    sinc_table: &[f32],
+    frac: f32,
+) {
+    crate::speex::sse3::interpolate_step_single(
+        in_slice, out_slice, out_stride, out_sample, oversample, offset, n,
+        sinc_table, frac,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+#[target_feature(enable = "sse3")]
+pub unsafe fn interpolate_step_double(
+    in_slice: &[f32],
+    out_slice: &mut [f32],
+    out_stride: usize,
+    out_sample: usize,
+    oversample: usize,
+    offset: usize,
+    n: usize,
+    sinc_table: &[f32],
+    frac: f32,
+) {
+    crate::speex::sse3::interpolate_step_double(
+        in_slice, out_slice, out_stride, out_sample, oversample, offset, n,
+        sinc_table, frac,
+    );
+}
+
+#[target_feature(enable = "sse3")]
+pub unsafe fn direct_step_single(
+    in_slice: &[f32],
+    out_slice: &mut [f32],
+    out_stride: usize,
+    out_sample: usize,
+    n: usize,
+    sinc_table: &[f32],
+) {
+    crate::speex::sse3::direct_step_single(
+        in_slice, out_slice, out_stride, out_sample, n, sinc_table,
+    );
+}
+
+#[target_feature(enable = "sse3")]
+pub unsafe fn direct_step_double(
+    in_slice: &[f32],
+    out_slice: &mut [f32],
+    out_stride: usize,
+    out_sample: usize,
+    n: usize,
+    sinc_table: &[f32],
+) {
+    crate::speex::sse3::direct_step_double(
+        in_slice, out_slice, out_stride, out_sample, n, sinc_table,
+    );
+}


### PR DESCRIPTION
it selects proper avx/sse3/native feature at run time
dynnative wrappers added because rustc forbids using inline(always) and
target_feature together