### PR TITLE
resampler: fix clippy lints

### DIFF
--- a/benches/resampling_rust.rs
+++ b/benches/resampling_rust.rs
@@ -32,14 +32,14 @@ fn resample_rs() {
             .process_float(0, &fin[off..off + in_len], &mut fout[..out_len])
             .unwrap();
 
-        off += in_len as usize;
+        off += in_len;
         avail += INBLOCK as isize - in_len as isize;
 
         if off >= INBLOCK {
             off -= INBLOCK;
         }
 
-        data.push(fout[..out_len as usize].to_vec());
+        data.push(fout[..out_len].to_vec());
 
         rate += 5000;
         if rate > 128000 {

--- a/examples/testresample.rs
+++ b/examples/testresample.rs
@@ -43,14 +43,14 @@ fn main() {
             rate, off, prev_in_len, prev_out_len, in_len, out_len
         );
 
-        off += in_len as usize;
+        off += in_len;
         avail += INBLOCK as isize - in_len as isize;
 
         if off >= INBLOCK {
             off -= INBLOCK;
         }
 
-        data.push(fout[..out_len as usize].to_vec());
+        data.push(fout[..out_len].to_vec());
 
         rate += 5000;
         if rate > 128000 {

--- a/fft/src/fftwrap.rs
+++ b/fft/src/fftwrap.rs
@@ -62,7 +62,7 @@ impl DrftLookup {
 
         out.iter_mut()
             .zip(in_0.iter())
-            .take(self.n as usize)
+            .take(self.n)
             .for_each(|(o, i)| *o = scale * *i);
 
         self.spx_drft_forward(out);
@@ -72,7 +72,7 @@ impl DrftLookup {
         if in_0 == out {
             eprintln!("FFT should not be done in-place");
         } else {
-            out.copy_from_slice(&in_0[..self.n as usize]);
+            out.copy_from_slice(&in_0[..self.n]);
         }
 
         self.spx_drft_backward(out);
@@ -91,7 +91,7 @@ impl DrftLookup {
             return;
         }
 
-        let mut trigcache_temp = self.trigcache[self.n as usize..].to_vec();
+        let mut trigcache_temp = self.trigcache[self.n..].to_vec();
 
         drftf1(
             self.n as i32,
@@ -101,7 +101,7 @@ impl DrftLookup {
             &mut self.splitcache,
         );
 
-        self.trigcache[self.n as usize..].copy_from_slice(&trigcache_temp);
+        self.trigcache[self.n..].copy_from_slice(&trigcache_temp);
     }
 
     pub fn spx_drft_backward(&mut self, data: &mut [f32]) {
@@ -109,7 +109,7 @@ impl DrftLookup {
             return;
         }
 
-        let mut trigcache_temp = self.trigcache[self.n as usize..].to_vec();
+        let mut trigcache_temp = self.trigcache[self.n..].to_vec();
 
         drftb1(
             self.n as i32,
@@ -119,6 +119,6 @@ impl DrftLookup {
             &mut self.splitcache,
         );
 
-        self.trigcache[self.n as usize..].copy_from_slice(&trigcache_temp);
+        self.trigcache[self.n..].copy_from_slice(&trigcache_temp);
     }
 }

--- a/resampler/src/speex.rs
+++ b/resampler/src/speex.rs
@@ -204,9 +204,9 @@ impl SpeexResamplerState {
             out_stride: 1,
             buffer_size: 160,
             oversample: 0,
-            last_sample: vec![0; nb_channels as usize],
-            magic_samples: vec![0; nb_channels as usize],
-            samp_frac_num: vec![0; nb_channels as usize],
+            last_sample: vec![0; nb_channels],
+            magic_samples: vec![0; nb_channels],
+            samp_frac_num: vec![0; nb_channels],
         };
         st.set_quality(quality);
         st.set_rate_frac(ratio_num, ratio_den, in_rate, out_rate);
@@ -325,7 +325,7 @@ impl SpeexResamplerState {
                     channel_index,
                     &mut yselfack.as_mut_slice(),
                     ochunk,
-                ) as u32;
+                );
                 ochunk -= omagic;
                 olen -= omagic
             }
@@ -365,8 +365,8 @@ impl SpeexResamplerState {
 
             ilen -= ichunk;
             olen -= ochunk;
-            out = &mut out[(ochunk + omagic * ostride_save as u32) as usize..];
-            in_0 = &in_0[(ichunk * istride_save as u32) as usize..];
+            out = &mut out[(ochunk + omagic * ostride_save) as usize..];
+            in_0 = &in_0[(ichunk * istride_save) as usize..];
         }
         self.out_stride = ostride_save;
         *in_len -= ilen;
@@ -821,9 +821,9 @@ fn resampler_basic_zero(
         out[(out_stride * out_sample) as usize] = 0.0;
         out_sample += 1;
         last_sample += int_advance;
-        samp_frac_num += frac_advance as u32;
+        samp_frac_num += frac_advance;
         if samp_frac_num >= den_rate {
-            samp_frac_num -= den_rate as u32;
+            samp_frac_num -= den_rate;
             last_sample += 1
         }
     }
@@ -884,7 +884,7 @@ fn resampler_basic_interpolate_single(
 
         out_sample += 1;
         last_sample += int_advance;
-        samp_frac_num += frac_advance as u32;
+        samp_frac_num += frac_advance;
         if samp_frac_num >= den_rate {
             samp_frac_num -= den_rate;
             last_sample += 1;
@@ -1146,9 +1146,9 @@ fn resampler_basic_direct_single(
 
         out_sample += 1;
         last_sample += int_advance;
-        samp_frac_num += frac_advance as u32;
+        samp_frac_num += frac_advance;
         if samp_frac_num >= den_rate {
-            samp_frac_num -= den_rate as u32;
+            samp_frac_num -= den_rate;
             last_sample += 1
         }
     }
@@ -1189,13 +1189,13 @@ fn resampler_basic_direct_double(
 
         out_sample += 1;
         last_sample += int_advance;
-        samp_frac_num += frac_advance as u32;
+        samp_frac_num += frac_advance;
         if samp_frac_num >= den_rate {
-            samp_frac_num -= den_rate as u32;
+            samp_frac_num -= den_rate;
             last_sample += 1;
         }
     }
-    st.last_sample[channel_index as usize] = last_sample as u32;
+    st.last_sample[channel_index as usize] = last_sample;
     st.samp_frac_num[channel_index as usize] = samp_frac_num;
     out_sample as i32
 }
@@ -1243,7 +1243,7 @@ fn speex_resampler_process_native(
         out_len,
     );
     if st.last_sample[channel_index as usize] < *in_len {
-        *in_len = st.last_sample[channel_index as usize] as u32;
+        *in_len = st.last_sample[channel_index as usize];
     }
     *out_len = out_sample as u32;
     st.last_sample[channel_index as usize] -= *in_len;
@@ -1268,7 +1268,7 @@ fn speex_resampler_magic<'a, 'b>(
         st,
         channel_index,
         &mut tmp_in_len,
-        *out,
+        out,
         &mut out_len,
     );
     st.magic_samples[channel_idx] -= tmp_in_len;
@@ -1282,7 +1282,7 @@ fn speex_resampler_magic<'a, 'b>(
             .for_each(|(x, &y)| *x = y);
     }
     let value: &'b mut [f32] = mem::take(out);
-    *out = &mut value[(out_len * st.out_stride as u32) as usize..];
+    *out = &mut value[(out_len * st.out_stride) as usize..];
     out_len
 }
 

--- a/resampler/src/speex/native.rs
+++ b/resampler/src/speex/native.rs
@@ -24,7 +24,7 @@ pub fn interpolate_step_single(
 ) {
     let mut accum: [f32; 4] = [0.; 4];
     in_slice.iter().zip(0..n).for_each(|(&curr_in, j)| {
-        let idx = (2 + (j + 1) * oversample as usize) - offset as usize;
+        let idx = (2 + (j + 1) * oversample) - offset;
         accum.iter_mut().zip(sinc_table.iter().skip(idx)).for_each(
             |(v, &s)| {
                 *v += curr_in * s;
@@ -33,7 +33,7 @@ pub fn interpolate_step_single(
     });
     let mut interp: [f32; 4] = [0.; 4];
     cubic_coef(frac, &mut interp);
-    out_slice[(out_stride * out_sample) as usize] = interp
+    out_slice[(out_stride * out_sample)] = interp
         .iter()
         .zip(accum.iter())
         .map(|(&x, &y)| x * y)
@@ -55,7 +55,7 @@ pub fn interpolate_step_double(
 ) {
     let mut accum: [f64; 4] = [0.0; 4];
     in_slice.iter().zip(0..n).for_each(|(&curr_in, j)| {
-        let idx = (2 + (j + 1) * oversample as usize) - offset as usize;
+        let idx = (2 + (j + 1) * oversample) - offset;
         accum.iter_mut().zip(sinc_table.iter().skip(idx)).for_each(
             |(v, &s)| {
                 *v += (curr_in * s) as f64;
@@ -64,7 +64,7 @@ pub fn interpolate_step_double(
     });
     let mut interp: [f32; 4] = [0.; 4];
     cubic_coef(frac, &mut interp);
-    out_slice[(out_stride * out_sample) as usize] = interp
+    out_slice[(out_stride * out_sample)] = interp
         .iter()
         .zip(accum.iter())
         .map(|(&x, &y)| x * y as f32)
@@ -83,10 +83,10 @@ pub fn direct_step_single(
     let mut sum: f32 = 0.0;
     let mut j = 0;
     while j < n {
-        sum += sinc_table[j as usize] * in_slice[j as usize];
+        sum += sinc_table[j] * in_slice[j];
         j += 1
     }
-    out_slice[(out_stride * out_sample) as usize] = sum;
+    out_slice[(out_stride * out_sample)] = sum;
 }
 
 #[inline(always)]
@@ -102,20 +102,13 @@ pub fn direct_step_double(
     let mut j = 0;
 
     while j < n {
-        accum[0usize] +=
-            f64::from(sinc_table[j as usize] * in_slice[j as usize]);
-        accum[1usize] += f64::from(
-            sinc_table[(j + 1) as usize] * in_slice[(j + 1) as usize],
-        );
-        accum[2usize] += f64::from(
-            sinc_table[(j + 2) as usize] * in_slice[(j + 2) as usize],
-        );
-        accum[3usize] += f64::from(
-            sinc_table[(j + 3) as usize] * in_slice[(j + 3) as usize],
-        );
+        accum[0usize] += f64::from(sinc_table[j] * in_slice[j]);
+        accum[1usize] += f64::from(sinc_table[(j + 1)] * in_slice[(j + 1)]);
+        accum[2usize] += f64::from(sinc_table[(j + 2)] * in_slice[(j + 2)]);
+        accum[3usize] += f64::from(sinc_table[(j + 3)] * in_slice[(j + 3)]);
         j += 4
     }
     let sum: f64 =
         accum[0usize] + accum[1usize] + accum[2usize] + accum[3usize];
-    out_slice[(out_stride * out_sample) as usize] = sum as f32;
+    out_slice[(out_stride * out_sample)] = sum as f32;
 }

--- a/tests/resampler.rs
+++ b/tests/resampler.rs
@@ -78,15 +78,15 @@ mod comparison {
             assert_eq!(in_len, in_len_native);
             assert_eq!(out_len, out_len_native);
 
-            off += in_len as usize;
+            off += in_len;
             avail += INBLOCK as isize - in_len as isize;
 
             if off >= INBLOCK {
                 off -= INBLOCK;
             }
 
-            let fout_s = &fout[..out_len as usize];
-            let fout_native_s = &fout_native[..out_len as usize];
+            let fout_s = &fout[..out_len];
+            let fout_native_s = &fout_native[..out_len];
 
             fout_s
                 .iter()


### PR DESCRIPTION
This is largely removing redundant casts.